### PR TITLE
Add support for proliant DA subsystem Disk enclosures

### DIFF
--- a/plugins-scripts/HP/Proliant.pm
+++ b/plugins-scripts/HP/Proliant.pm
@@ -336,7 +336,11 @@ EOEO
           if ($self->{runtime}->{options}->{hpacucli}) {
             #1 oder 0. pfad selber finden
             my $hpacucli = undef;
-            if (-e '/usr/sbin/hpacucli') {
+            if (-e '/usr/sbin/hpssacli') {
+              $hpacucli = '/usr/sbin/hpssacli';
+            } elsif (-e '/usr/local/sbin/hpssacli') {
+              $hpacucli = '/usr/local/sbin/hpssacli';
+            } elsif (-e '/usr/sbin/hpacucli') {
               $hpacucli = '/usr/sbin/hpacucli';
             } elsif (-e '/usr/local/sbin/hpacucli') {
               $hpacucli = '/usr/local/sbin/hpacucli';

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem.pm
@@ -92,6 +92,8 @@ sub assemble {
       scalar(@{$self->{controllers}}));
   $self->trace(3, sprintf "has %d accelerators",
       scalar(@{$self->{accelerators}})) if exists $self->{accelerators};
+  $self->trace(3, sprintf "has %d enclosures",
+      scalar(@{$self->{enclosures}}));
   $self->trace(3, sprintf "has %d physical_drives",
       scalar(@{$self->{physical_drives}}));
   $self->trace(3, sprintf "has %d logical_drives",
@@ -100,20 +102,22 @@ sub assemble {
       scalar(@{$self->{spare_drives}}));
   my $found = {
       accelerators => {},
+      enclosures => {},
       logical_drives => {},
       physical_drives => {},
       spare_drives => {},
   };
   # found->{komponente}->{controllerindex} ist ein array
   # von teilen, die zu einem controller gehoeren
-  foreach my $item (qw(accelerators logical_drives physical_drives spare_drives)) {
+  foreach my $item (qw(accelerators enclosures logical_drives physical_drives spare_drives)) {
+    next if ($item eq "enclosures" && ! exists $self->{$item});
     foreach (@{$self->{$item}}) {
       $found->{item}->{$_->{controllerindex}} = []
           unless exists $found->{$item}->{$_->{controllerindex}};
       push(@{$found->{$item}->{$_->{controllerindex}}}, $_);
     }
   }
-  foreach my $item (qw(accelerators logical_drives physical_drives spare_drives)) {
+  foreach my $item (qw(accelerators enclosures logical_drives physical_drives spare_drives)) {
     foreach (@{$self->{controllers}}) {
       if (exists $found->{$item}->{$_->{controllerindex}}) {
         $_->{$item} = $found->{$item}->{$_->{controllerindex}};
@@ -145,6 +149,11 @@ sub has_physical_drives {
 sub has_logical_drives {
   my $self = shift;
   return scalar(@{$self->{logical_drives}});
+}
+
+sub has_enclosures {
+  my $self = shift;
+  return scalar(@{$self->{enclosures}});
 }
 
 1;

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da/CLI.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da/CLI.pm
@@ -10,6 +10,7 @@ sub new {
   my $self = {
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],
@@ -30,7 +31,9 @@ sub init {
   my $tmpaccel = {};
   my $tmpld = {};
   my $tmppd = {};
+  my $tmpencl = {};
   my $cntlindex = 0;
+  my $enclosureindex = 0;
   my $ldriveindex = 0;
   my $pdriveindex = 0;
   my $incontroller = 0;
@@ -86,6 +89,7 @@ sub init {
   }
   $slot = 0;
   $cntlindex = 0;
+  $enclosureindex = 0;
   $ldriveindex = 0;
   $pdriveindex = 0;
   foreach (split(/\n/, $hpacucli)) {
@@ -104,6 +108,16 @@ sub init {
       #}
       $slot = $2;
       $pdriveindex = 1;
+    } elsif (/([\s\w]+) Enclosure at Port ([\w]+), Box (\d+), (.*)/) {
+      $enclosureindex++;
+      $tmpencl->{$slot}->{$enclosureindex}->{cpqDaEnclCntlrIndex} = $cntlindex;
+      $tmpencl->{$slot}->{$enclosureindex}->{cpqDaEnclIndex} = $enclosureindex;
+      $tmpencl->{$slot}->{$enclosureindex}->{cpqDaEnclPort} = $2;
+      $tmpencl->{$slot}->{$enclosureindex}->{cpqDaEnclBox} = $3;
+      $tmpencl->{$slot}->{$enclosureindex}->{cpqDaEnclCondition} = $4;
+      $tmpencl->{$slot}->{$enclosureindex}->{cpqDaEnclStatus} =
+          $tmpencl->{$slot}->{$enclosureindex}->{cpqDaEnclCondition};
+      $tmpencl->{$slot}->{$enclosureindex}->{cpqDaLogDrvPhyDrvIDs} = 'unknown';
     } elsif (/logicaldrive\s+(.+?)\s+\((.*)\)/) {
       # logicaldrive 1 (683.5 GB, RAID 5, OK)
       # logicaldrive 1 (683.5 GB, RAID 5, OK)
@@ -158,6 +172,7 @@ sub init {
         ! $self->identified($tmpcntl->{$slot}->{cpqDaCntlrModel})) {
       delete $tmpcntl->{$slot};
       delete $tmpaccel->{$slot};
+      delete $tmpencl->{$slot};
       delete $tmpld->{$slot};
       delete $tmppd->{$slot};
     }
@@ -182,6 +197,14 @@ sub init {
     push(@{$self->{accelerators}},
         HP::Proliant::Component::DiskSubsystem::Da::Accelerator->new(
             %{$tmpaccel->{$slot}}));
+  }
+  foreach my $slot (keys %{$tmpencl}) {
+    foreach my $enclosureindex (keys %{$tmpencl->{$slot}}) {
+      $tmpencl->{$slot}->{$enclosureindex}->{runtime} = $self->{runtime};
+      push(@{$self->{enclosures}},
+          HP::Proliant::Component::DiskSubsystem::Da::Enclosure->new(
+              %{$tmpencl->{$slot}->{$enclosureindex}}));
+    }
   }
   foreach my $slot (keys %{$tmpld}) {
     foreach my $ldriveindex (keys %{$tmpld->{$slot}}) {

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da/CLI.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da/CLI.pm
@@ -108,7 +108,7 @@ sub init {
       #}
       $slot = $2;
       $pdriveindex = 1;
-    } elsif (/([\s\w]+) Enclosure at Port ([\w]+), Box (\d+), (.*)/) {
+    } elsif (/([\s\w]+) at Port ([\w]+), Box (\d+), (.*)/) {
       $enclosureindex++;
       $tmpencl->{$slot}->{$enclosureindex}->{cpqDaEnclCntlrIndex} = $cntlindex;
       $tmpencl->{$slot}->{$enclosureindex}->{cpqDaEnclIndex} = $enclosureindex;

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da/SNMP.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da/SNMP.pm
@@ -11,6 +11,7 @@ sub new {
   my $self = { 
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Fca.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Fca.pm
@@ -14,6 +14,7 @@ sub new {
     host_controllers => [],
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Fca/CLI.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Fca/CLI.pm
@@ -10,6 +10,7 @@ sub new {
   my $self = {
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Fca/SNMP.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Fca/SNMP.pm
@@ -11,6 +11,7 @@ sub new {
   my $self = { 
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Ide.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Ide.pm
@@ -12,6 +12,7 @@ sub new {
     rawdata => $params{rawdata},
     method => $params{method},
     controllers => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Ide/CLI.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Ide/CLI.pm
@@ -10,6 +10,7 @@ sub new {
   my $self = {
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Ide/SNMP.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Ide/SNMP.pm
@@ -11,6 +11,7 @@ sub new {
   my $self = { 
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Sas.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Sas.pm
@@ -12,6 +12,7 @@ sub new {
     rawdata => $params{rawdata},
     method => $params{method},
     controllers => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Sas/CLI.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Sas/CLI.pm
@@ -10,6 +10,7 @@ sub new {
   my $self = {
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Sas/SNMP.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Sas/SNMP.pm
@@ -11,6 +11,7 @@ sub new {
   my $self = { 
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Scsi.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Scsi.pm
@@ -12,6 +12,7 @@ sub new {
     rawdata => $params{rawdata},
     method => $params{method},
     controllers => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Scsi/CLI.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Scsi/CLI.pm
@@ -10,6 +10,7 @@ sub new {
   my $self = {
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Scsi/SNMP.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Scsi/SNMP.pm
@@ -11,6 +11,7 @@ sub new {
   my $self = { 
     controllers => [],
     accelerators => [],
+    enclosures => [],
     physical_drives => [],
     logical_drives => [],
     spare_drives => [],


### PR DESCRIPTION
Add support for proliant DA subsystem Disk enclosures. The check for disk enclosures requires that hpssacli is used instead of hpacucli, either by symlinking hpacucli to hpssacli or modifying the code to use hpssacli if available but this is not done here.
Tested on  G6, G8 and G9 systems in various configuration with MSA60, MSA70, D2700 and D3700 enclosures
Only works through CLI with DA subsystem and not SNMP/other subsystem since I have no idea how that works/cannot test