### PR TITLE
Use HP::StorageWorks for HP MSA systems

### DIFF
--- a/plugins-scripts/HP/Server.pm
+++ b/plugins-scripts/HP/Server.pm
@@ -52,6 +52,9 @@ sub new {
       } elsif ($self->{productname} =~ /StorageWorks/i) {
         bless $self, 'HP::StorageWorks';
         $self->trace(3, 'using HP::StorageWorks');
+      } elsif ($self->{productname} =~ /MSA/i) {
+        bless $self, 'HP::StorageWorks';
+        $self->trace(3, 'using HP::StorageWorks');
       } elsif ($self->{productname} =~ /StoreEasy/i) {
         bless $self, 'HP::Proliant::SNMP';
         $self->trace(3, 'using HP::Proliant::SNMP');


### PR DESCRIPTION
Use the HP::StorageWorks module to support systems like HP MSA 2040 SAS.
