### PR TITLE
Handle the name change of hpssacli to ssacli

### DIFF
--- a/plugins-scripts/HP/Proliant.pm
+++ b/plugins-scripts/HP/Proliant.pm
@@ -341,19 +341,16 @@ EOEO
           if ($self->{runtime}->{options}->{hpacucli}) {
             #1 oder 0. pfad selber finden
             my $hpacucli = undef;
-            if (-e '/usr/sbin/hpssacli') {
-              $hpacucli = '/usr/sbin/hpssacli';
-            } elsif (-e '/usr/local/sbin/hpssacli') {
-              $hpacucli = '/usr/local/sbin/hpssacli';
-            } elsif (-e '/usr/sbin/hpacucli') {
-              $hpacucli = '/usr/sbin/hpacucli';
-            } elsif (-e '/usr/local/sbin/hpacucli') {
-              $hpacucli = '/usr/local/sbin/hpacucli';
-            } elsif (-e '/usr/sbin/hpssacli') {
-              $hpacucli = '/usr/sbin/hpssacli';
-            } elsif (-e '/usr/local/sbin/hpssacli') {
-              $hpacucli = '/usr/local/sbin/hpssacli';
-            } else {
+            CLIEXECTEST:
+            foreach my $cliexec (qw(ssacli hpssacli hpacucli)) {
+              foreach my $clipaths (qw(/usr/sbin/ /usr/local/sbin/ /sbin/)) {
+                if (-e $clipaths . $cliexec) {
+                  $hpacucli = $clipaths . $cliexec;
+                  last CLIEXECTEST;
+                }
+              }
+            }
+            if (! defined $hpacucli) {
               $hpacucli = $hpasmcli;
               $hpacucli =~ s/^sudo\s*//;
               $hpacucli =~ s/hpasmcli/hpacucli/;


### PR DESCRIPTION
HP decided to rename hpssacli to ssacli in newer versions and hpssacli is not installed by ssacli-2.60-19.0
- Add ssacli as an alias to hpssacli in new naming scheme
- Rewrite check of executable to not hardcode each combination