### PR TITLE
Refactor message formatting

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,7 @@ How to "compile" the check_hpasm script.
 
 1) Run the configure script to initialize variables and create a Makefile, etc.
 
-	./configure --prefix=BASEDIRECTORY --with-nagios-user=SOMEUSER --with-nagios-group=SOMEGROUP --with-perl=PATH_TO_PERL --with-noinst-level=LEVEL --with-degrees=UNIT --with-perfdata --with-hpacucli
+	./configure --prefix=BASEDIRECTORY --with-nagios-user=SOMEUSER --with-nagios-group=SOMEGROUP --with-perl=PATH_TO_PERL --with-noinst-level=LEVEL --with-degrees=UNIT --enable-perfdata --enable-hpacucli
 
    a) Replace BASEDIRECTORY with the path of the directory under which Nagios
       is installed (default is '/usr/local/nagios')

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.14.1 -*- Autoconf -*-
+# generated automatically by aclocal 1.15 -*- Autoconf -*-
 
-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
+# Copyright (C) 1996-2014 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -20,7 +20,7 @@ You have another version of autoconf.  It may work, but is not guaranteed to.
 If you have problems, you may need to regenerate the build system entirely.
 To do so, use the procedure documented by the package, typically 'autoreconf'.])])
 
-# Copyright (C) 2002-2013 Free Software Foundation, Inc.
+# Copyright (C) 2002-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -32,10 +32,10 @@ To do so, use the procedure documented by the package, typically 'autoreconf'.])
 # generated from the m4 files accompanying Automake X.Y.
 # (This private macro should not be called outside this file.)
 AC_DEFUN([AM_AUTOMAKE_VERSION],
-[am__api_version='1.14'
+[am__api_version='1.15'
 dnl Some users find AM_AUTOMAKE_VERSION and mistake it for a way to
 dnl require some minimum version.  Point them to the right macro.
-m4_if([$1], [1.14.1], [],
+m4_if([$1], [1.15], [],
       [AC_FATAL([Do not call $0, use AM_INIT_AUTOMAKE([$1]).])])dnl
 ])
 
@@ -51,14 +51,14 @@ m4_define([_AM_AUTOCONF_VERSION], [])
 # Call AM_AUTOMAKE_VERSION and AM_AUTOMAKE_VERSION so they can be traced.
 # This function is AC_REQUIREd by AM_INIT_AUTOMAKE.
 AC_DEFUN([AM_SET_CURRENT_AUTOMAKE_VERSION],
-[AM_AUTOMAKE_VERSION([1.14.1])dnl
+[AM_AUTOMAKE_VERSION([1.15])dnl
 m4_ifndef([AC_AUTOCONF_VERSION],
   [m4_copy([m4_PACKAGE_VERSION], [AC_AUTOCONF_VERSION])])dnl
 _AM_AUTOCONF_VERSION(m4_defn([AC_AUTOCONF_VERSION]))])
 
 # AM_AUX_DIR_EXPAND                                         -*- Autoconf -*-
 
-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
+# Copyright (C) 2001-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -103,15 +103,14 @@ _AM_AUTOCONF_VERSION(m4_defn([AC_AUTOCONF_VERSION]))])
 # configured tree to be moved without reconfiguration.
 
 AC_DEFUN([AM_AUX_DIR_EXPAND],
-[dnl Rely on autoconf to set up CDPATH properly.
-AC_PREREQ([2.50])dnl
-# expand $ac_aux_dir to an absolute path
-am_aux_dir=`cd $ac_aux_dir && pwd`
+[AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT])dnl
+# Expand $ac_aux_dir to an absolute path.
+am_aux_dir=`cd "$ac_aux_dir" && pwd`
 ])
 
 # Do all the work for Automake.                             -*- Autoconf -*-
 
-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
+# Copyright (C) 1996-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -201,8 +200,8 @@ AC_REQUIRE([AC_PROG_MKDIR_P])dnl
 # <http://lists.gnu.org/archive/html/automake/2012-07/msg00001.html>
 # <http://lists.gnu.org/archive/html/automake/2012-07/msg00014.html>
 AC_SUBST([mkdir_p], ['$(MKDIR_P)'])
-# We need awk for the "check" target.  The system "awk" is bad on
-# some platforms.
+# We need awk for the "check" target (and possibly the TAP driver).  The
+# system "awk" is bad on some platforms.
 AC_REQUIRE([AC_PROG_AWK])dnl
 AC_REQUIRE([AC_PROG_MAKE_SET])dnl
 AC_REQUIRE([AM_SET_LEADING_DOT])dnl
@@ -275,7 +274,11 @@ to "yes", and re-run configure.
 END
     AC_MSG_ERROR([Your 'rm' program is bad, sorry.])
   fi
-fi])
+fi
+dnl The trailing newline in this macro's definition is deliberate, for
+dnl backward compatibility and to allow trailing 'dnl'-style comments
+dnl after the AM_INIT_AUTOMAKE invocation. See automake bug#16841.
+])
 
 dnl Hook into '_AC_COMPILER_EXEEXT' early to learn its expansion.  Do not
 dnl add the conditional right here, as _AC_COMPILER_EXEEXT may be further
@@ -304,7 +307,7 @@ for _am_header in $config_headers :; do
 done
 echo "timestamp for $_am_arg" >`AS_DIRNAME(["$_am_arg"])`/stamp-h[]$_am_stamp_count])
 
-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
+# Copyright (C) 2001-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -315,7 +318,7 @@ echo "timestamp for $_am_arg" >`AS_DIRNAME(["$_am_arg"])`/stamp-h[]$_am_stamp_co
 # Define $install_sh.
 AC_DEFUN([AM_PROG_INSTALL_SH],
 [AC_REQUIRE([AM_AUX_DIR_EXPAND])dnl
-if test x"${install_sh}" != xset; then
+if test x"${install_sh+set}" != xset; then
   case $am_aux_dir in
   *\ * | *\	*)
     install_sh="\${SHELL} '$am_aux_dir/install-sh'" ;;
@@ -325,7 +328,7 @@ if test x"${install_sh}" != xset; then
 fi
 AC_SUBST([install_sh])])
 
-# Copyright (C) 2003-2013 Free Software Foundation, Inc.
+# Copyright (C) 2003-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -346,7 +349,7 @@ AC_SUBST([am__leading_dot])])
 
 # Fake the existence of programs that GNU maintainers use.  -*- Autoconf -*-
 
-# Copyright (C) 1997-2013 Free Software Foundation, Inc.
+# Copyright (C) 1997-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -385,7 +388,7 @@ fi
 
 # Helper functions for option handling.                     -*- Autoconf -*-
 
-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
+# Copyright (C) 2001-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -414,7 +417,7 @@ AC_DEFUN([_AM_SET_OPTIONS],
 AC_DEFUN([_AM_IF_OPTION],
 [m4_ifset(_AM_MANGLE_OPTION([$1]), [$2], [$3])])
 
-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
+# Copyright (C) 2001-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -433,7 +436,7 @@ AC_DEFUN([AM_RUN_LOG],
 
 # Check to make sure that the build environment is sane.    -*- Autoconf -*-
 
-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
+# Copyright (C) 1996-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -514,7 +517,7 @@ AC_CONFIG_COMMANDS_PRE(
 rm -f conftest.file
 ])
 
-# Copyright (C) 2009-2013 Free Software Foundation, Inc.
+# Copyright (C) 2009-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -574,7 +577,7 @@ AC_SUBST([AM_BACKSLASH])dnl
 _AM_SUBST_NOTMAKE([AM_BACKSLASH])dnl
 ])
 
-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
+# Copyright (C) 2001-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -602,7 +605,7 @@ fi
 INSTALL_STRIP_PROGRAM="\$(install_sh) -c -s"
 AC_SUBST([INSTALL_STRIP_PROGRAM])])
 
-# Copyright (C) 2006-2013 Free Software Foundation, Inc.
+# Copyright (C) 2006-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -621,7 +624,7 @@ AC_DEFUN([AM_SUBST_NOTMAKE], [_AM_SUBST_NOTMAKE($@)])
 
 # Check how to create a tarball.                            -*- Autoconf -*-
 
-# Copyright (C) 2004-2013 Free Software Foundation, Inc.
+# Copyright (C) 2004-2014 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,

--- a/plugins-scripts/HP/BladeSystem.pm
+++ b/plugins-scripts/HP/BladeSystem.pm
@@ -140,8 +140,7 @@ sub collect {
     my $cpqRackMibCondition = '1.3.6.1.4.1.232.22.1.3.0';
     $self->trace(3, 'getting cpqRackMibCondition');
     if (! exists $self->{rawdata}->{$cpqRackMibCondition}) {
-        $self->add_message(CRITICAL,
-            'snmpwalk returns no health data (cpqrack-mib)');
+        $self->add_message(CRITICAL, 'snmpwalk returns no health data (cpqrack-mib)');
     }
   } else {
     my $net_snmp_version = Net::SNMP->VERSION(); # 5.002000 or 6.000000
@@ -166,8 +165,7 @@ sub collect {
           $result->{$cpqRackMibCondition} eq 'noSuchInstance' ||
           $result->{$cpqRackMibCondition} eq 'noSuchObject' ||
           $result->{$cpqRackMibCondition} eq 'endOfMibView') {
-        $self->add_message(CRITICAL,
-            'snmpwalk returns no health data (cpqrack-mib)');
+        $self->add_message(CRITICAL, 'snmpwalk returns no health data (cpqrack-mib)');
         $session->close;
       } else {
         $self->trace(3, 'getting cpqRackMibCondition done');

--- a/plugins-scripts/HP/BladeSystem/Component/CommonEnclosureSubsystem/FanSubsystem.pm
+++ b/plugins-scripts/HP/BladeSystem/Component/CommonEnclosureSubsystem/FanSubsystem.pm
@@ -107,11 +107,11 @@ sub new {
 sub check {
   my $self = shift;
   $self->blacklist('f', $self->{name});
-  $self->add_info(sprintf 'fan %s is %s, location is %s, redundance is %s, condition is %s',
-      $self->{name}, $self->{cpqRackCommonEnclosureFanPresent},
-      $self->{cpqRackCommonEnclosureFanLocation},
-      $self->{cpqRackCommonEnclosureFanRedundant},
-      $self->{cpqRackCommonEnclosureFanCondition});
+  $self->add_info('fan %s is %s, location is %s, redundance is %s, condition is %s',
+      \'name', \'cpqRackCommonEnclosureFanPresent',
+      \'cpqRackCommonEnclosureFanLocation',
+      \'cpqRackCommonEnclosureFanRedundant',
+      \'cpqRackCommonEnclosureFanCondition');
   if ($self->{cpqRackCommonEnclosureFanCondition} eq 'degraded') {
     $self->{info} .= sprintf ", (SparePartNum: %s)", $self->{cpqRackCommonEnclosureFanSparePartNumber};
     $self->add_message(WARNING, $self->{info});

--- a/plugins-scripts/HP/BladeSystem/Component/CommonEnclosureSubsystem/FuseSubsystem.pm
+++ b/plugins-scripts/HP/BladeSystem/Component/CommonEnclosureSubsystem/FuseSubsystem.pm
@@ -95,9 +95,9 @@ sub new {
 sub check {
   my $self = shift;
   $self->blacklist('fu', $self->{name});
-  $self->add_info(sprintf 'fuse %s is %s, location is %s, condition is %s',
-      $self->{name}, $self->{cpqRackCommonEnclosureFusePresent},
-      $self->{cpqRackCommonEnclosureFuseLocation}, $self->{cpqRackCommonEnclosureFuseCondition});
+  $self->add_info('fuse %s is %s, location is %s, condition is %s',
+      \'name', \'cpqRackCommonEnclosureFusePresent',
+      \'cpqRackCommonEnclosureFuseLocation', \'cpqRackCommonEnclosureFuseCondition');
   if ($self->{cpqRackCommonEnclosureFuseCondition} eq 'failed') {
     $self->add_message(CRITICAL, $self->{info});
   } elsif ($self->{cpqRackCommonEnclosureFuseCondition} ne 'ok') {

--- a/plugins-scripts/HP/BladeSystem/Component/CommonEnclosureSubsystem/TempSubsystem.pm
+++ b/plugins-scripts/HP/BladeSystem/Component/CommonEnclosureSubsystem/TempSubsystem.pm
@@ -126,17 +126,17 @@ sub check {
   my $self = shift;
   $self->blacklist('t', $self->{name});
   if ($self->{cpqRackCommonEnclosureTempCurrent} > $self->{cpqRackCommonEnclosureTempThreshold}) {
-    $self->add_info(sprintf "%s temperature too high (%d%s)",
-        $self->{cpqRackCommonEnclosureTempLocation},
-        $self->{cpqRackCommonEnclosureTempCurrent},
-        $self->{runtime}->{options}->{celsius} ? "C" : "F");
+    $self->add_info("%s temperature too high (%d%s)",
+        \'cpqRackCommonEnclosureTempLocation',
+        \'cpqRackCommonEnclosureTempCurrent',
+        $self->{runtime}{options}{celsius} ? "C" : "F");
     $self->add_message(CRITICAL, $self->{info});
   } else {
-    $self->add_info(sprintf "%s temperature is %d%s (%d max)",
-        $self->{cpqRackCommonEnclosureTempLocation},
-        $self->{cpqRackCommonEnclosureTempCurrent},
+    $self->add_info("%s temperature is %d%s (%d max)",
+        \'cpqRackCommonEnclosureTempLocation',
+        \'cpqRackCommonEnclosureTempCurrent',
         $self->{runtime}->{options}->{celsius} ? "C" : "F",
-        $self->{cpqRackCommonEnclosureTempThreshold});
+        \'cpqRackCommonEnclosureTempThreshold');
   }
   if ($self->{runtime}->{options}->{perfdata} == 2) {
     $self->{runtime}->{plugin}->add_perfdata(
@@ -154,8 +154,7 @@ sub check {
         critical => $self->{cpqRackCommonEnclosureTempThreshold}
     );
   }
-  $self->add_extendedinfo(sprintf "temp_%s=%d", 
-      $self->{name}, $self->{cpqRackCommonEnclosureTempCurrent});
+  $self->add_extendedinfo("temp_%s=%d", \'name', \'cpqRackCommonEnclosureTempCurrent');
 
 }
 

--- a/plugins-scripts/HP/BladeSystem/Component/PowerSupplySubsystem.pm
+++ b/plugins-scripts/HP/BladeSystem/Component/PowerSupplySubsystem.pm
@@ -182,15 +182,15 @@ sub check {
     if ($self->{cpqRackPowerSupplyCondition} eq 'degraded') {
       $info .= sprintf " (SparePartNum %s)", $self->{cpqRackPowerSupplySparePartNumber};
       $self->add_message(WARNING, $info);
-      $self->add_info(sprintf 'power supply %s status is %s, inp.line status is %s',
-          $self->{name}, $self->{cpqRackPowerSupplyStatus},
-          $self->{cpqRackPowerSupplySupplyInputLineStatus});
+      $self->add_info('power supply %s status is %s, inp.line status is %s',
+          \'name', \'cpqRackPowerSupplyStatus',
+          \'cpqRackPowerSupplySupplyInputLineStatus');
     } elsif ($self->{cpqRackPowerSupplyCondition} eq 'failed') {
       $info .= sprintf " (SparePartNum %s)", $self->{cpqRackPowerSupplySparePartNumber};
       $self->add_message(CRITICAL, $info);
-      $self->add_info(sprintf 'power supply %s status is %s, inp.line status is %s',
-          $self->{name}, $self->{cpqRackPowerSupplyStatus},
-          $self->{cpqRackPowerSupplySupplyInputLineStatus});
+      $self->add_info('power supply %s status is %s, inp.line status is %s',
+          \'name', \'cpqRackPowerSupplyStatus',
+          \'cpqRackPowerSupplySupplyInputLineStatus');
     } 
     if ($self->{runtime}->{options}->{perfdata} != 2) {
       $self->{runtime}->{plugin}->add_perfdata(

--- a/plugins-scripts/HP/BladeSystem/Component/ServerBladeSubsystem.pm
+++ b/plugins-scripts/HP/BladeSystem/Component/ServerBladeSubsystem.pm
@@ -128,19 +128,18 @@ sub new {
 sub check {
   my $self = shift;
   $self->blacklist('sb', $self->{name});
-  my $info = sprintf 'server blade %s \'%s\' is %s, status is %s, powered is %s',
-      $self->{name}, $self->{cpqRackServerBladeName}, $self->{cpqRackServerBladePresent},
-      $self->{cpqRackServerBladeStatus}, $self->{cpqRackServerBladePowered};
-  $self->add_info($info);
+  $self->add_info('server blade %s \'%s\' is %s, status is %s, powered is %s',
+      \'name', \'cpqRackServerBladeName', \'cpqRackServerBladePresent',
+      \'cpqRackServerBladeStatus', \'cpqRackServerBladePowered');
   if ($self->{cpqRackServerBladePowered} eq 'on') {
     if ($self->{cpqRackServerBladeStatus} eq 'degraded') {
-      $self->add_message(WARNING, sprintf 'server blade %s diag is \'%s\', post status is %s',
-          $self->{cpqRackServerBladeName}, $self->{cpqRackServerBladeDiagnosticString},
-          $self->{cpqRackServerBladePOSTStatus});
+      $self->add_message(WARNING, 'server blade %s diag is \'%s\', post status is %s',
+          \'cpqRackServerBladeName', \'cpqRackServerBladeDiagnosticString',
+          \'cpqRackServerBladePOSTStatus');
     } elsif ($self->{cpqRackServerBladeStatus} eq 'failed') {
-      $self->add_message(CRITICAL, sprintf 'server blade %s diag is \'%s\', post status is %s',
-          $self->{cpqRackServerBladeName}, $self->{cpqRackServerBladeDiagnosticString},
-          $self->{cpqRackServerBladePOSTStatus});
+      $self->add_message(CRITICAL, 'server blade %s diag is \'%s\', post status is %s',
+          \'cpqRackServerBladeName', \'cpqRackServerBladeDiagnosticString',
+          \'cpqRackServerBladePOSTStatus');
     } 
   }
 } 

--- a/plugins-scripts/HP/FCMGMT/Component/SensorSubsystem.pm
+++ b/plugins-scripts/HP/FCMGMT/Component/SensorSubsystem.pm
@@ -73,19 +73,15 @@ sub check {
   if ($self->{cpqSeSensorStatus} ne "ok") {
     if ($self->{runtime}->{options}{scrapiron} &&
         ($self->{cpqSeSensorStatus} eq "unknown")) {
-      $self->add_info(sprintf "cpu %d probably ok (%s)",
-          $self->{cpqSeSensorUnitIndex}, $self->{cpqSeSensorStatus});
+      $self->add_info("cpu %d probably ok (%s)", \'cpqSeSensorUnitIndex', \'cpqSeSensorStatus');
     } else {
-      $self->add_info(sprintf "cpu %d needs attention (%s)",
-          $self->{cpqSeSensorUnitIndex}, $self->{cpqSeSensorStatus});
+      $self->add_info("cpu %d needs attention (%s)", \'cpqSeSensorUnitIndex', \'cpqSeSensorStatus');
       $self->add_message(CRITICAL, $self->{info});
     }
   } else {
-    $self->add_info(sprintf "cpu %d is %s", 
-        $self->{cpqSeSensorUnitIndex}, $self->{cpqSeSensorStatus});
+    $self->add_info("cpu %d is %s", \'cpqSeSensorUnitIndex', \'cpqSeSensorStatus');
   }
-  $self->add_extendedinfo(sprintf "cpu_%s=%s",
-      $self->{cpqSeSensorUnitIndex}, $self->{cpqSeSensorStatus});
+  $self->add_extendedinfo("cpu_%s=%s", \'cpqSeSensorUnitIndex', \'cpqSeSensorStatus');
 }
 
 sub dump {

--- a/plugins-scripts/HP/Proliant.pm
+++ b/plugins-scripts/HP/Proliant.pm
@@ -415,11 +415,10 @@ EOEO
               }
             } else {
               if ($self->{runtime}->{options}->{noinstlevel} eq 'ok') {
-                $self->add_message(OK,
-                    'hpacucli is not installed. let\'s hope the best...');
+                $self->add_message(OK, 'hpacucli is not installed. let\'s hope the best...');
               } else {
                 $self->add_message(
-                    uc $self->{runtime}->{options}->{noinstlevel},
+                    uc $self->{runtime}{options}{noinstlevel},
                     'hpacucli is not installed.');
               }
             }
@@ -428,8 +427,7 @@ EOEO
       }
     } else {
       if ($self->{runtime}->{options}->{noinstlevel} eq 'ok') {
-        $self->add_message(OK,
-            'hpasm is not installed, i can only guess');
+        $self->add_message(OK, 'hpasm is not installed, i can only guess');
         $self->{noinst_hint} = 1;
       } else {
         $self->add_message(
@@ -491,20 +489,17 @@ sub check_hpasm_client {
     if (grep /Could not communicate with hpasmd/, @output) {
       $self->add_message(CRITICAL, 'hpasmd needs to be restarted');
     } elsif (grep /(asswor[dt]:)|(You must be root)/, @output) {
-      $self->add_message(UNKNOWN,
-          sprintf "insufficient rights to call %s", $hpasmcli);
+      $self->add_message(UNKNOWN, "insufficient rights to call $hpasmcli");
     } elsif (grep /must have a tty/, @output) {
       $self->add_message(CRITICAL,
           'sudo must be configured with requiretty=no (man sudo)');
     } elsif (grep /ERROR: hpasmcli only runs on HPE Proliant Servers/, @output) {
       $self->add_message(UNKNOWN, "hpasmcli detected incompatible hardware");
     } elsif (! grep /CLEAR/, @output) {
-      $self->add_message(UNKNOWN,
-          sprintf "insufficient rights to call %s", $hpasmcli);
+      $self->add_message(UNKNOWN, "insufficient rights to call $hpasmcli");
     }
   } else {
-    $self->add_message(UNKNOWN,
-        sprintf "insufficient rights to call %s", $hpasmcli);
+    $self->add_message(UNKNOWN, "insufficient rights to call $hpasmcli");
   }
 }
 
@@ -517,18 +512,14 @@ sub check_hpacu_client {
     if (grep /Another instance of hpacucli is running/, @output) {
       $self->add_message(UNKNOWN, 'another hpacucli is running');
     } elsif (grep /You need to have administrator rights/, @output) {
-      $self->add_message(UNKNOWN,
-          sprintf "insufficient rights to call %s", $hpacucli);
+      $self->add_message(UNKNOWN, "insufficient rights to call $hpacucli");
     } elsif (grep /(asswor[dt]:)|(You must be root)/, @output) {
-      $self->add_message(UNKNOWN,
-          sprintf "insufficient rights to call %s", $hpacucli);
+      $self->add_message(UNKNOWN, "insufficient rights to call $hpacucli");
     } elsif (! grep /(CLI Syntax)|(ACU CLI)/, @output) {
-      $self->add_message(UNKNOWN,
-          sprintf "insufficient rights to call %s", $hpacucli);
+      $self->add_message(UNKNOWN, "insufficient rights to call $hpacucli");
     }
   } else {
-    $self->add_message(UNKNOWN,
-        sprintf "insufficient rights to call %s", $hpacucli);
+    $self->add_message(UNKNOWN, "insufficient rights to call $hpacucli");
   }
 }
 
@@ -600,8 +591,7 @@ sub collect {
     }
     if (! exists $self->{rawdata}->{$cpqHeMibCondition} &&
         ! exists $self->{rawdata}->{$cpqSeMibCondition}) { # vlt. geht doch was
-        $self->add_message(CRITICAL,
-            'snmpwalk returns no health data (cpqhlth-mib)');
+        $self->add_message(CRITICAL, 'snmpwalk returns no health data (cpqhlth-mib)');
     }
     $self->{fullrawdata} = {};
     %{$self->{fullrawdata}} = %{$self->{rawdata}};
@@ -651,8 +641,7 @@ sub collect {
           $result->{$cpqHeMibCondition} eq 'noSuchInstance' ||
           $result->{$cpqHeMibCondition} eq 'noSuchObject' ||
           $result->{$cpqHeMibCondition} eq 'endOfMibView') {
-        $self->add_message(CRITICAL,
-            'snmpwalk returns no health data (cpqhlth-mib)');
+        $self->add_message(CRITICAL, 'snmpwalk returns no health data (cpqhlth-mib)');
         $session->close;
       } else {
         # this is not reliable. many agents return 4=failed

--- a/plugins-scripts/HP/Proliant/Component/CpuSubsystem.pm
+++ b/plugins-scripts/HP/Proliant/Component/CpuSubsystem.pm
@@ -86,19 +86,18 @@ sub check {
   if ($self->{cpqSeCpuStatus} ne "ok") {
     if ($self->{runtime}->{options}{scrapiron} &&
         ($self->{cpqSeCpuStatus} eq "unknown")) {
-      $self->add_info(sprintf "cpu %d probably ok (%s)",
-          $self->{cpqSeCpuUnitIndex}, $self->{cpqSeCpuStatus});
+      $self->add_info("cpu %d probably ok (%s)",
+          \'cpqSeCpuUnitIndex', \'cpqSeCpuStatus');
     } else {
-      $self->add_info(sprintf "cpu %d needs attention (%s)",
-          $self->{cpqSeCpuUnitIndex}, $self->{cpqSeCpuStatus});
+      $self->add_info("cpu %d needs attention (%s)",
+          \'cpqSeCpuUnitIndex', \'cpqSeCpuStatus');
       $self->add_message(CRITICAL, $self->{info});
     }
   } else {
-    $self->add_info(sprintf "cpu %d is %s", 
-        $self->{cpqSeCpuUnitIndex}, $self->{cpqSeCpuStatus});
+    $self->add_info("cpu %d is %s", 
+        \'cpqSeCpuUnitIndex', \'cpqSeCpuStatus');
   }
-  $self->add_extendedinfo(sprintf "cpu_%s=%s",
-      $self->{cpqSeCpuUnitIndex}, $self->{cpqSeCpuStatus});
+  $self->add_extendedinfo("cpu_%s=%s", \'cpqSeCpuUnitIndex', \'cpqSeCpuStatus');
 }
 
 sub dump {

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da.pm
@@ -91,13 +91,13 @@ sub check {
   if ($self->{cpqDaCntlrCondition} eq 'other') {
     if (scalar(@{$self->{physical_drives}})) {
       $self->add_message(CRITICAL,
-          sprintf 'da controller %s in slot %s needs attention', 
-              $self->{cpqDaCntlrIndex}, $self->{cpqDaCntlrSlot});
-      $self->add_info(sprintf 'da controller %s in slot %s needs attention',
-          $self->{cpqDaCntlrIndex}, $self->{cpqDaCntlrSlot});
+          'da controller %s in slot %s needs attention', 
+              \'cpqDaCntlrIndex', \'cpqDaCntlrSlot');
+      $self->add_info('da controller %s in slot %s needs attention',
+          \'cpqDaCntlrIndex', \'cpqDaCntlrSlot');
     } else {
-      $self->add_info(sprintf 'da controller %s in slot %s is ok and unused',
-          $self->{cpqDaCntlrIndex}, $self->{cpqDaCntlrSlot});
+      $self->add_info('da controller %s in slot %s is ok and unused',
+          \'cpqDaCntlrIndex', \'cpqDaCntlrSlot');
       $self->{blacklisted} = 1;
     }
   } elsif ($self->{cpqDaCntlrCondition} eq 'degraded') {
@@ -108,20 +108,20 @@ sub check {
       # message was already written in the accel code
     } else {
       $self->add_message(CRITICAL,
-          sprintf 'da controller %s in slot %s needs attention', 
-              $self->{cpqDaCntlrIndex}, $self->{cpqDaCntlrSlot});
-      $self->add_info(sprintf 'da controller %s in slot %s needs attention',
-          $self->{cpqDaCntlrIndex}, $self->{cpqDaCntlrSlot});
+          'da controller %s in slot %s needs attention', 
+              \'cpqDaCntlrIndex', \'cpqDaCntlrSlot');
+      $self->add_info('da controller %s in slot %s needs attention',
+          \'cpqDaCntlrIndex', \'cpqDaCntlrSlot');
     }
   } elsif ($self->{cpqDaCntlrCondition} ne 'ok') {
     $self->add_message(CRITICAL,
-        sprintf 'da controller %s in slot %s needs attention', 
-            $self->{cpqDaCntlrIndex}, $self->{cpqDaCntlrSlot});
-    $self->add_info(sprintf 'da controller %s in slot %s needs attention',
-        $self->{cpqDaCntlrIndex}, $self->{cpqDaCntlrSlot});
+        'da controller %s in slot %s needs attention', 
+            \'cpqDaCntlrIndex', \'cpqDaCntlrSlot');
+    $self->add_info('da controller %s in slot %s needs attention',
+        \'cpqDaCntlrIndex', \'cpqDaCntlrSlot');
   } else {
-    $self->add_info(sprintf 'da controller %s in slot %s is ok', 
-        $self->{cpqDaCntlrIndex}, $self->{cpqDaCntlrSlot});
+    $self->add_info('da controller %s in slot %s is ok', 
+        \'cpqDaCntlrIndex', \'cpqDaCntlrSlot');
   }
 } 
 
@@ -178,16 +178,14 @@ sub new {
 sub check {
   my $self = shift;
   $self->blacklist('daac', $self->{cpqDaAccelCntlrIndex});
-  $self->add_info(sprintf 'controller accelerator is %s',
-      $self->{cpqDaAccelCondition});
+  $self->add_info('controller accelerator is %s', \'cpqDaAccelCondition');
   if ($self->{cpqDaAccelCondition} eq "failed" || $self->{cpqDaAccelCondition} eq "degraded") {
-    $self->add_message(CRITICAL, sprintf
+    $self->add_message(CRITICAL,
         "controller accelerator is %s (reason: %s) and needs attention",
-        $self->{cpqDaAccelCondition}, $self->{cpqDaAccelErrCode});
+        \'cpqDaAccelCondition', \'cpqDaAccelErrCode');
   }
   $self->blacklist('daacb', $self->{cpqDaAccelCntlrIndex});
-  $self->add_info(sprintf 'controller accelerator battery is %s',
-      $self->{cpqDaAccelBattery});
+  $self->add_info('controller accelerator battery is %s', \'cpqDaAccelBattery');
   if ($self->{cpqDaAccelBattery} eq "notPresent") {
   } elsif ($self->{cpqDaAccelBattery} eq "recharging") {
     $self->add_message(WARNING, "controller accelerator battery recharging");
@@ -249,13 +247,9 @@ sub new {
 sub check {
   my $self = shift;
   $self->blacklist('dae', $self->{name});
-  $self->add_info(
-      sprintf "disk enclosure %s is %s",
-          $self->{name}, $self->{cpqDaEnclCondition});
+  $self->add_info("disk enclosure %s is %s", \'name', \'cpqDaEnclCondition');
   if ($self->{cpqDaEnclCondition} !~ /^OK/) {
-    $self->add_message(CRITICAL,
-        sprintf "disk enclosure %s is %s",
-            $self->{name}, $self->{cpqDaEnclCondition});
+    $self->add_message(CRITICAL, "disk enclosure %s is %s", \'name', \'cpqDaEnclCondition');
   }
 }
 
@@ -304,19 +298,15 @@ sub new {
 sub check {
   my $self = shift;
   $self->blacklist('dald', $self->{name});
-  $self->add_info(sprintf "logical drive %s is %s (%s)",
-          $self->{name}, $self->{cpqDaLogDrvStatus},
-          $self->{cpqDaLogDrvFaultTol});
+  $self->add_info("logical drive %s is %s (%s)",
+          \'name', \'cpqDaLogDrvStatus',
+          \'cpqDaLogDrvFaultTol');
   if ($self->{cpqDaLogDrvCondition} ne "ok") {
     if ($self->{cpqDaLogDrvStatus} =~ 
         /rebuild|recovering|recovery|expanding|queued/) {
-      $self->add_message(WARNING,
-          sprintf "logical drive %s is %s", 
-              $self->{name}, $self->{cpqDaLogDrvStatus});
+      $self->add_message(WARNING, "logical drive %s is %s", \'name', \'cpqDaLogDrvStatus');
     } else {
-      $self->add_message(CRITICAL,
-          sprintf "logical drive %s is %s",
-              $self->{name}, $self->{cpqDaLogDrvStatus});
+      $self->add_message(CRITICAL, "logical drive %s is %s", \'name', \'cpqDaLogDrvStatus');
     }
   } 
 }
@@ -364,13 +354,10 @@ sub new {
 sub check {
   my $self = shift;
   $self->blacklist('dapd', $self->{name});
-  $self->add_info(
-      sprintf "physical drive %s is %s",
-          $self->{name}, $self->{cpqDaPhyDrvCondition});
+  $self->add_info("physical drive %s is %s",
+          \'name', \'cpqDaPhyDrvCondition');
   if ($self->{cpqDaPhyDrvCondition} ne 'ok') {
-    $self->add_message(CRITICAL,
-        sprintf "physical drive %s is %s", 
-            $self->{name}, $self->{cpqDaPhyDrvCondition});
+    $self->add_message(CRITICAL, "physical drive %s is %s", \'name', \'cpqDaPhyDrvCondition');
   }
 }
 

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Fca.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Fca.pm
@@ -112,14 +112,11 @@ sub new {
 sub check {
   my $self = shift;
   if ($self->{cpqFcaMibCondition} eq 'other') {
-    $self->add_message(OK,
-        sprintf 'fcal overall condition is other, update your drivers, please');
+    $self->add_message(OK, 'fcal overall condition is other, update your drivers, please');
   } elsif ($self->{cpqFcaMibCondition} ne 'ok') {
-    $self->add_message(CRITICAL, 
-        sprintf 'fcal overall condition is %s', $self->{cpqFcaMibCondition});
+    $self->add_message(CRITICAL, 'fcal overall condition is %s', \'cpqFcaMibCondition');
   }
-  $self->{info} = 
-      sprintf 'fcal overall condition is %s', $self->{cpqFcaMibCondition};
+  $self->{info} = "fcal overall condition is $self->{cpqFcaMibCondition}";
 }
 
 sub dump {

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Ide.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Ide.pm
@@ -73,24 +73,24 @@ sub check {
   if ($self->{cpqIdeControllerOverallCondition} eq 'other') {
     if (scalar(@{$self->{physical_drives}})) {
       $self->add_message(CRITICAL,
-          sprintf 'ide controller %s in slot %s needs attention',
-              $self->{cpqIdeControllerIndex}, $self->{cpqIdeControllerSlot});
-      $self->add_info(sprintf 'ide controller %s in slot %s needs attention',
-          $self->{cpqIdeControllerIndex}, $self->{cpqIdeControllerSlot});
+          'ide controller %s in slot %s needs attention',
+          \'cpqIdeControllerIndex', \'cpqIdeControllerSlot');
+      $self->add_info('ide controller %s in slot %s needs attention',
+          \'cpqIdeControllerIndex', \'cpqIdeControllerSlot');
     } else {
-      $self->add_info(sprintf 'ide controller %s in slot %s is ok and unused',
-          $self->{cpqIdeControllerIndex}, $self->{cpqIdeControllerSlot});
+      $self->add_info('ide controller %s in slot %s is ok and unused',
+          \'cpqIdeControllerIndex', \'cpqIdeControllerSlot');
       $self->{blacklisted} = 1;
     }
   } elsif ($self->{cpqIdeControllerOverallCondition} ne 'ok') {
     $self->add_message(CRITICAL,
-        sprintf 'ide controller %s in slot %s needs attention',
-            $self->{cpqIdeControllerIndex}, $self->{cpqIdeControllerSlot});
-    $self->add_info(sprintf 'ide controller %s in slot %s needs attention',
-        $self->{cpqIdeControllerIndex}, $self->{cpqIdeControllerSlot});
+        'ide controller %s in slot %s needs attention',
+        \'cpqIdeControllerIndex', \'cpqIdeControllerSlot');
+    $self->add_info('ide controller %s in slot %s needs attention',
+        \'cpqIdeControllerIndex', \'cpqIdeControllerSlot');
   } else {
-    $self->add_info(sprintf 'ide controller %s in slot %s is ok',
-        $self->{cpqIdeControllerIndex}, $self->{cpqIdeControllerSlot});
+    $self->add_info('ide controller %s in slot %s is ok',
+        \'cpqIdeControllerIndex', \'cpqIdeControllerSlot');
   }
   foreach (@{$self->{logical_drives}}) {
     $_->check();
@@ -160,17 +160,16 @@ sub check {
     if ($self->{cpqIdeLogicalDriveStatus} =~ 
         /rebuild/) {
       $self->add_message(WARNING,
-          sprintf "logical drive %s is %s", 
-              $self->{name}, $self->{cpqIdeLogicalDriveStatus});
+          "logical drive %s is %s", 
+          \'name', \'cpqIdeLogicalDriveStatus');
     } else {
       $self->add_message(CRITICAL,
-          sprintf "logical drive %s is %s",
-              $self->{name}, $self->{cpqIdeLogicalDriveStatus});
+          "logical drive %s is %s",
+              \'name', \'cpqIdeLogicalDriveStatus');
     }
   } 
-  $self->add_info(
-      sprintf "logical drive %s is %s", $self->{name},
-          $self->{cpqIdeLogicalDriveStatus});
+  $self->add_info("logical drive %s is %s", \'name',
+          \'cpqIdeLogicalDriveStatus');
 }
 
 sub dump {
@@ -221,12 +220,11 @@ sub check {
   $self->blacklist('idepd', $self->{name});
   if ($self->{cpqIdeAtaDiskCondition} ne 'ok') {
     $self->add_message(CRITICAL,
-        sprintf "physical drive %s is %s", 
-            $self->{name}, $self->{cpqIdeAtaDiskCondition});
+        "physical drive %s is %s", 
+            \'name', \'cpqIdeAtaDiskCondition');
   }
-  $self->add_info(
-      sprintf "physical drive %s is %s", 
-          $self->{name}, $self->{cpqIdeAtaDiskCondition});
+  $self->add_info("physical drive %s is %s", 
+          \'name', \'cpqIdeAtaDiskCondition');
 }
 
 sub dump {

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Sas.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Sas.pm
@@ -74,24 +74,20 @@ sub check {
   if ($self->{cpqSasHbaCondition} eq 'other') {
     if (scalar(@{$self->{physical_drives}})) {
       $self->add_message(CRITICAL,
-          sprintf 'sas controller in slot %s needs attention',
-              $self->{cpqSasHbaSlot});
-      $self->add_info(sprintf 'sas controller in slot %s needs attention',
-          $self->{cpqSasHbaSlot});
+          'sas controller in slot %s needs attention',
+          \'cpqSasHbaSlot');
+      $self->add_info('sas controller in slot %s needs attention', \'cpqSasHbaSlot');
     } else {
-      $self->add_info(sprintf 'sas controller in slot %s is ok and unused',
-          $self->{cpqSasHbaSlot});
+      $self->add_info('sas controller in slot %s is ok and unused', \'cpqSasHbaSlot');
       $self->{blacklisted} = 1;
     }
   } elsif ($self->{cpqSasHbaCondition} ne 'ok') {
     $self->add_message(CRITICAL,
         sprintf 'sas controller in slot %s needs attention',
             $self->{cpqSasHbaSlot});
-    $self->add_info(sprintf 'sas controller in slot %s needs attention',
-        $self->{cpqSasHbaSlot});
+    $self->add_info('sas controller in slot %s needs attention', \'cpqSasHbaSlot');
   } else {
-    $self->add_info(sprintf 'sas controller in slot %s is ok',
-        $self->{cpqSasHbaSlot});
+    $self->add_info('sas controller in slot %s is ok', \'cpqSasHbaSlot');
   }
   foreach (@{$self->{logical_drives}}) {
     $_->check();
@@ -161,17 +157,16 @@ sub check {
     if ($self->{cpqSasLogDrvStatus} =~ 
         /rebuild|recovering|expanding|queued/) {
       $self->add_message(WARNING,
-          sprintf "logical drive %s is %s", 
-              $self->{name}, $self->{cpqSasLogDrvStatus});
+          "logical drive %s is %s", 
+          \'name', \'cpqSasLogDrvStatus');
     } else {
       $self->add_message(CRITICAL,
-          sprintf "logical drive %s is %s",
-              $self->{name}, $self->{cpqSasLogDrvStatus});
+          "logical drive %s is %s",
+          \'name', \'cpqSasLogDrvStatus');
     }
   } 
-  $self->add_info(
-      sprintf "logical drive %s is %s (%s)", $self->{name},
-          $self->{cpqSasLogDrvStatus}, $self->{cpqSasLogDrvRaidLevel});
+  $self->add_info("logical drive %s is %s (%s)",
+      \'name', \'cpqSasLogDrvStatus', \'cpqSasLogDrvRaidLevel');
 }
 
 sub dump {
@@ -216,13 +211,11 @@ sub check {
   my $self = shift;
   $self->blacklist('sapd', $self->{name});
   if ($self->{cpqSasPhyDrvCondition} ne 'ok') {
-    $self->add_message(CRITICAL,
-        sprintf "physical drive %s is %s", 
-            $self->{name}, $self->{cpqSasPhyDrvCondition});
+    $self->add_message(CRITICAL, "physical drive %s is %s", 
+            \'name', \'cpqSasPhyDrvCondition');
   }
-  $self->add_info(
-      sprintf "physical drive %s is %s", 
-          $self->{name}, $self->{cpqSasPhyDrvCondition});
+  $self->add_info("physical drive %s is %s", 
+      \'name', \'cpqSasPhyDrvCondition');
 }
 
 sub dump {

--- a/plugins-scripts/HP/Proliant/Component/EventSubsystem.pm
+++ b/plugins-scripts/HP/Proliant/Component/EventSubsystem.pm
@@ -181,12 +181,12 @@ sub check {
   # POST events only if they date maximum from reboot-5min
   # younger than critical? -> critical
   # 
-  $self->add_info(sprintf "Event: %d Added: %s Class: (%s) %s %s",
-      $self->{cpqHeEventLogEntryNumber},
-      $self->{cpqHeEventLogUpdateTime},
-      $self->{cpqHeEventLogEntryClass},
-      $self->{cpqHeEventLogEntrySeverity},
-      $self->{cpqHeEventLogErrorDesc});
+  $self->add_info("Event: %d Added: %s Class: (%s) %s %s",
+      \'cpqHeEventLogEntryNumber',
+      \'cpqHeEventLogUpdateTime',
+      \'cpqHeEventLogEntryClass',
+      \'cpqHeEventLogEntrySeverity',
+      \'cpqHeEventLogErrorDesc');
   if ($self->{cpqHeEventLogEntrySeverity} eq "caution" ||
       $self->{cpqHeEventLogEntrySeverity} eq "critical") {
     # also watch 10 minutes of booting before the operating system starts ticking

--- a/plugins-scripts/HP/Proliant/Component/EventSubsystem/SNMP.pm
+++ b/plugins-scripts/HP/Proliant/Component/EventSubsystem/SNMP.pm
@@ -210,7 +210,7 @@ sub overall_check {
       $self->add_info('eventlog system is ok');
     } else {
       $result = 0;
-      $self->add_info(sprintf "eventlog system is %s", $self->{eventstatus});
+      $self->add_info("eventlog system is %s", \'eventstatus');
     }
   } else {
     $result = 0;

--- a/plugins-scripts/HP/Proliant/Component/FanSubsystem.pm
+++ b/plugins-scripts/HP/Proliant/Component/FanSubsystem.pm
@@ -125,36 +125,33 @@ sub new {
 sub check { 
   my $self = shift;
   $self->blacklist('f', $self->{cpqHeFltTolFanIndex});
-  $self->add_info(sprintf 'fan %d is %s, speed is %s, pctmax is %s%%, '.
+  $self->add_info('fan %d is %s, speed is %s, pctmax is %s%%, '.
       'location is %s, redundance is %s, partner is %s',
-      $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanPresent},
-      $self->{cpqHeFltTolFanSpeed}, $self->{cpqHeFltTolFanPctMax},
-      $self->{cpqHeFltTolFanLocale}, $self->{cpqHeFltTolFanRedundant},
-      $self->{cpqHeFltTolFanRedundantPartner});
-  $self->add_extendedinfo(sprintf 'fan_%s=%d%%',
-      $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanPctMax});
+      \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanPresent',
+      \'cpqHeFltTolFanSpeed', \'cpqHeFltTolFanPctMax',
+      \'cpqHeFltTolFanLocale', \'cpqHeFltTolFanRedundant',
+      \'cpqHeFltTolFanRedundantPartner');
+  $self->add_extendedinfo('fan_%s=%d%%', \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanPctMax');
   if ($self->{cpqHeFltTolFanPresent} eq 'present') {
     if ($self->{cpqHeFltTolFanSpeed} eq 'high') { 
-      $self->add_info(sprintf 'fan %d (%s) runs at high speed',
-          $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanLocale});
+      $self->add_info('fan %d (%s) runs at high speed',
+          \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanLocale');
       $self->add_message(CRITICAL, $self->{info});
     } elsif ($self->{cpqHeFltTolFanSpeed} ne 'normal') {
-      $self->add_info(sprintf 'fan %d (%s) needs attention',
-          $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanLocale});
+      $self->add_info('fan %d (%s) needs attention',
+          \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanLocale');
       $self->add_message(CRITICAL, $self->{info});
     }
     if ($self->{cpqHeFltTolFanCondition} eq 'failed') {
-      $self->add_info(sprintf 'fan %d (%s) failed',
-          $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanLocale});
+      $self->add_info('fan %d (%s) failed',
+          \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanLocale');
       $self->add_message(CRITICAL, $self->{info});
     } elsif ($self->{cpqHeFltTolFanCondition} eq 'degraded') {
-      $self->add_info(sprintf 'fan %d (%s) degraded',
-          $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanLocale});
+      $self->add_info('fan %d (%s) degraded', \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanLocale');
       $self->add_message(WARNING, $self->{info});
     } elsif ($self->{cpqHeFltTolFanCondition} ne 'ok' &&
         $self->{cpqHeFltTolFanCondition} ne 'other') {
-      $self->add_info(sprintf 'fan %d (%s) is not ok',
-          $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanLocale});
+      $self->add_info('fan %d (%s) is not ok', \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanLocale');
       $self->add_message(WARNING, $self->{info});
     }
     if ($self->{cpqHeFltTolFanRedundant} eq 'notRedundant') {
@@ -172,8 +169,8 @@ sub check {
         if ($self->{overallhealth}) {
           # da ist sogar das system der meinung, dass etwas faul ist
           if (! $self->{runtime}->{options}->{ignore_fan_redundancy}) {
-            $self->add_info(sprintf 'fan %d (%s) is not redundant',
-                $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanLocale});
+            $self->add_info('fan %d (%s) is not redundant',
+              \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanLocale');
             $self->add_message(WARNING, $self->{info});
           }
         } else {
@@ -187,12 +184,11 @@ sub check {
       # maybe redundancy is not supported at all
     }
   } elsif ($self->{cpqHeFltTolFanPresent} eq 'failed') { # from cli
-    $self->add_info(sprintf 'fan %d (%s) failed',
-        $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanLocale});
+    $self->add_info('fan %d (%s) failed', \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanLocale');
     $self->add_message(CRITICAL, $self->{info});
   } elsif ($self->{cpqHeFltTolFanPresent} eq 'absent') {
-    $self->add_info(sprintf 'fan %d (%s) needs attention (is absent)',
-        $self->{cpqHeFltTolFanIndex}, $self->{cpqHeFltTolFanLocale});
+    $self->add_info('fan %d (%s) needs attention (is absent)',
+      \'cpqHeFltTolFanIndex', \'cpqHeFltTolFanLocale');
     # weiss nicht, ob absent auch kaputt bedeuten kann
     # wenn nicht, dann wuerde man sich hier dumm und daemlich blacklisten
     #$self->add_message(CRITICAL, $self->{info});

--- a/plugins-scripts/HP/Proliant/Component/FanSubsystem/SNMP.pm
+++ b/plugins-scripts/HP/Proliant/Component/FanSubsystem/SNMP.pm
@@ -202,24 +202,20 @@ sub overall_check {
   if ($self->{sysstatus} && $self->{cpustatus}) {
     if ($self->{sysstatus} eq 'degraded') {
       $result = 1;
-      $self->add_message(WARNING,
-          sprintf 'system fan overall status is %s', $self->{sysstatus});
+      $self->add_message(WARNING, 'system fan overall status is %s', \'sysstatus');
     } elsif ($self->{sysstatus} eq 'failed') {
       $result = 2;
-      $self->add_message(CRITICAL,
-          sprintf 'system fan overall status is %s', $self->{sysstatus});
+      $self->add_message(CRITICAL, 'system fan overall status is %s', \'sysstatus');
     } 
     if ($self->{cpustatus} eq 'degraded') {
       $result = 1;
-      $self->add_message(WARNING,
-          sprintf 'cpu fan overall status is %s', $self->{cpustatus});
+      $self->add_message(WARNING, 'cpu fan overall status is %s', \'cpustatus');
     } elsif ($self->{cpustatus} eq 'failed') {
       $result = 2;
-      $self->add_message(CRITICAL,
-          sprintf 'cpu fan overall status is %s', $self->{cpustatus});
+      $self->add_message(CRITICAL, 'cpu fan overall status is %s', \'cpustatus');
     } 
-    $self->add_info(sprintf 'overall fan status: system=%s, cpu=%s',
-        $self->{sysstatus}, $self->{cpustatus});
+    $self->add_info('overall fan status: system=%s, cpu=%s',
+        \'sysstatus', \'cpustatus');
   } else {
     $result = 0;
     $self->add_info('this system seems to be water-cooled. no fans found');

--- a/plugins-scripts/HP/Proliant/Component/MemorySubsystem.pm
+++ b/plugins-scripts/HP/Proliant/Component/MemorySubsystem.pm
@@ -48,15 +48,15 @@ sub check {
   } else {
     if ($self->{runtime}->{options}->{ignore_dimms}) {
       $self->add_message(OK,
-          sprintf "ignoring %d dimms with status 'n/a' ",
+          "ignoring %d dimms with status 'n/a' ",
           scalar(grep { ($_->is_present()) } @{$self->{dimms}}));
     } elsif ($self->{runtime}->{options}->{buggy_firmware}) {
       $self->add_message(OK,
-          sprintf "ignoring %d dimms with status 'n/a' because of buggy firmware",
+          "ignoring %d dimms with status 'n/a' because of buggy firmware",
           scalar(grep { ($_->is_present()) } @{$self->{dimms}}));
     } else {
       $self->add_message(WARNING,
-        sprintf "status of all %d dimms is n/a (please upgrade firmware)",
+        "status of all %d dimms is n/a (please upgrade firmware)",
         scalar(grep { $_->is_present() } @{$self->{dimms}}));
         $errorfound++;
     }
@@ -66,8 +66,7 @@ sub check {
   }
   if (! $errorfound && $self->is_faulty()) {
   #if ($self->is_faulty()) {
-    $self->add_message(WARNING,
-        sprintf 'overall memory error found');
+    $self->add_message(WARNING, 'overall memory error found');
   }
 }
 
@@ -115,23 +114,21 @@ sub check {
   $self->blacklist('d', $self->{name});
   if (($self->{status} eq 'present') || ($self->{status} eq 'good')) {
     if ($self->{condition} eq 'other') {
-      $self->add_info(sprintf 'dimm %s (%s) is n/a',
-          $self->{name}, $self->{location});
+      $self->add_info('dimm %s (%s) is n/a',
+          \'name', \'location');
     } elsif ($self->{condition} ne 'ok') {
-      $self->add_info(
-        sprintf "dimm module %s (%s) needs attention (%s)",
-        $self->{name}, $self->{location}, $self->{condition});
+      $self->add_info("dimm module %s (%s) needs attention (%s)",
+        \'name', \'location', \'condition');
     } else {
-      $self->add_info(sprintf 'dimm module %s (%s) is %s',
-          $self->{name}, $self->{location}, $self->{condition});
+      $self->add_info('dimm module %s (%s) is %s',
+          \'name', \'location', \'condition');
     }
   } elsif ($self->{status} eq 'notPresent') {
-    $self->add_info(sprintf 'dimm module %s (%s) is not present',
-        $self->{name}, $self->{location});
+    $self->add_info('dimm module %s (%s) is not present',
+        \'name', \'location');
   } else {
-    $self->add_info(
-      sprintf "dimm module %s (%s) needs attention (%s)",
-      $self->{name}, $self->{location}, $self->{condition});
+    $self->add_info('dimm module %s (%s) needs attention (%s)',
+      \'name', \'location', \'condition');
   }
 }
 

--- a/plugins-scripts/HP/Proliant/Component/NicSubsystem.pm
+++ b/plugins-scripts/HP/Proliant/Component/NicSubsystem.pm
@@ -74,8 +74,7 @@ sub dump {
 sub overall_check {
   my $self = shift;
   if ($self->{lognicstatus} ne "ok") {
-    $self->add_info(sprintf 'overall logical nic status is %s',
-        $self->{lognicstatus});
+    $self->add_info('overall logical nic status is %s', \'lognicstatus');
   }
 }
 
@@ -109,22 +108,22 @@ sub check {
     if ($self->{cpqNicIfLogMapCondition} eq "other") {
       # simply ignore this. if there is a physical nic
       # it is usually unknown/other/scheissegal
-      $self->add_info(sprintf "logical nic %d (%s) is %s",
-          $self->{cpqNicIfLogMapIndex}, $self->{cpqNicIfLogMapDescription},
-          $self->{cpqNicIfLogMapCondition});
+      $self->add_info("logical nic %d (%s) is %s",
+          \'cpqNicIfLogMapIndex', \'cpqNicIfLogMapDescription',
+          \'cpqNicIfLogMapCondition');
     } elsif ($self->{cpqNicIfLogMapCondition} ne "ok") {
-      $self->add_info(sprintf "logical nic %d (%s) is %s (%s)",
-          $self->{cpqNicIfLogMapIndex}, $self->{cpqNicIfLogMapDescription},
-          $self->{cpqNicIfLogMapCondition}, $self->{cpqNicIfLogMapStatus});
+      $self->add_info("logical nic %d (%s) is %s (%s)",
+          \'cpqNicIfLogMapIndex', \'cpqNicIfLogMapDescription',
+          \'cpqNicIfLogMapCondition', \'cpqNicIfLogMapStatus');
       $self->add_message(CRITICAL, $self->{info});
     } else {
-      $self->add_info(sprintf "logical nic %d (%s) is %s",
-          $self->{cpqNicIfLogMapIndex}, $self->{cpqNicIfLogMapDescription},
-          $self->{cpqNicIfLogMapCondition});
+      $self->add_info("logical nic %d (%s) is %s",
+          \'cpqNicIfLogMapIndex', \'cpqNicIfLogMapDescription',
+          \'cpqNicIfLogMapCondition');
     }
   } else {
-    $self->add_info(sprintf "logical nic %d (%s) has 0 physical nics",
-        $self->{cpqNicIfLogMapIndex}, $self->{cpqNicIfLogMapDescription});
+    $self->add_info("logical nic %d (%s) has 0 physical nics",
+        \'cpqNicIfLogMapIndex', \'cpqNicIfLogMapDescription');
   }
 }
 
@@ -167,24 +166,24 @@ sub check {
   if ($self->{cpqNicIfPhysAdapterCondition} eq "other") {
     # hp doesnt output a clear status. i am optimistic, unknown/other
     # means "dont care"
-    $self->add_info(sprintf "physical nic %d (%s) is %s",
-        $self->{cpqNicIfPhysAdapterIndex}, $self->{cpqNicIfPhysAdapterRole},
-        $self->{cpqNicIfPhysAdapterCondition});
+    $self->add_info("physical nic %d (%s) is %s",
+        \'cpqNicIfPhysAdapterIndex', \'cpqNicIfPhysAdapterRole',
+        \'cpqNicIfPhysAdapterCondition');
   } elsif ($self->{cpqNicIfPhysAdapterCondition} ne "ok") {
-    $self->add_info(sprintf "physical nic %d (%s) is %s (%s,%s)",
-        $self->{cpqNicIfPhysAdapterIndex}, $self->{cpqNicIfPhysAdapterRole},
-        $self->{cpqNicIfPhysAdapterCondition},
-        $self->{cpqNicIfPhysAdapterState}, $self->{cpqNicIfPhysAdapterStatus});
+    $self->add_info("physical nic %d (%s) is %s (%s,%s)",
+        \'cpqNicIfPhysAdapterIndex', \'cpqNicIfPhysAdapterRole',
+        \'cpqNicIfPhysAdapterCondition',
+        \'cpqNicIfPhysAdapterState', \'cpqNicIfPhysAdapterStatus');
     $self->add_message(CRITICAL, $self->{info});
   } else {
     if ($self->{cpqNicIfPhysAdapterDuplexState} ne "full") {
-      $self->add_info(sprintf "physical nic %d (%s) is %s duplex",
-          $self->{cpqNicIfPhysAdapterIndex}, $self->{cpqNicIfPhysAdapterRole},
-          $self->{cpqNicIfPhysAdapterDuplexState});
+      $self->add_info("physical nic %d (%s) is %s duplex",
+          \'cpqNicIfPhysAdapterIndex', \'cpqNicIfPhysAdapterRole',
+          \'cpqNicIfPhysAdapterDuplexState');
     } else {
-      $self->add_info(sprintf "physical nic %d (%s) is %s",
-          $self->{cpqNicIfPhysAdapterIndex}, $self->{cpqNicIfPhysAdapterRole},
-          $self->{cpqNicIfPhysAdapterCondition});
+      $self->add_info("physical nic %d (%s) is %s",
+          \'cpqNicIfPhysAdapterIndex', \'cpqNicIfPhysAdapterRole',
+          \'cpqNicIfPhysAdapterCondition');
     }
   }
 }

--- a/plugins-scripts/HP/Proliant/Component/PowersupplySubsystem.pm
+++ b/plugins-scripts/HP/Proliant/Component/PowersupplySubsystem.pm
@@ -83,22 +83,19 @@ sub check {
   if ($self->{cpqHeFltTolPowerSupplyPresent} eq "present") {
     if ($self->{cpqHeFltTolPowerSupplyCondition} ne "ok") {
       if ($self->{cpqHeFltTolPowerSupplyCondition} eq "other") {
-        $self->add_info(sprintf "powersupply %d is missing",
-            $self->{cpqHeFltTolPowerSupplyBay});
+        $self->add_info("powersupply %d is missing", \'cpqHeFltTolPowerSupplyBay');
       } else {
-        $self->add_info(sprintf "powersupply %d needs attention (%s)",
-            $self->{cpqHeFltTolPowerSupplyBay},
-            $self->{cpqHeFltTolPowerSupplyCondition});
+        $self->add_info("powersupply %d needs attention (%s)",
+            \'cpqHeFltTolPowerSupplyBay',
+            \'cpqHeFltTolPowerSupplyCondition');
       }
       $self->add_message(CRITICAL, $self->{info});
     } else {
-      $self->add_info(sprintf "powersupply %d is %s",
-          $self->{cpqHeFltTolPowerSupplyBay},
-          $self->{cpqHeFltTolPowerSupplyCondition});
+      $self->add_info("powersupply %d is %s",
+          \'cpqHeFltTolPowerSupplyBay',
+          \'cpqHeFltTolPowerSupplyCondition');
     }
-    $self->add_extendedinfo(sprintf "ps_%s=%s",
-        $self->{cpqHeFltTolPowerSupplyBay},
-        $self->{cpqHeFltTolPowerSupplyCondition});
+    $self->add_extendedinfo("ps_%s=%s", \'cpqHeFltTolPowerSupplyBay', \'cpqHeFltTolPowerSupplyCondition');
     if ($self->{cpqHeFltTolPowerSupplyCapacityUsed} &&
         $self->{cpqHeFltTolPowerSupplyCapacityMaximum}) {
       if ($self->{runtime}->{options}->{perfdata}) {
@@ -118,12 +115,10 @@ sub check {
       }
     }
   } else {
-    $self->add_info(sprintf "powersupply %d is %s",
-        $self->{cpqHeFltTolPowerSupplyBay},
-        $self->{cpqHeFltTolPowerSupplyPresent});
-    $self->add_extendedinfo(sprintf "ps_%s=%s",
-        $self->{cpqHeFltTolPowerSupplyBay},
-        $self->{cpqHeFltTolPowerSupplyPresent});
+    $self->add_info("powersupply %d is %s",
+        \'cpqHeFltTolPowerSupplyBay',
+        \'cpqHeFltTolPowerSupplyPresent');
+    $self->add_extendedinfo("ps_%s=%s", \'cpqHeFltTolPowerSupplyBay', \'cpqHeFltTolPowerSupplyPresent');
   }
 }
 
@@ -174,29 +169,24 @@ sub check {
   if ($self->{cpqHePowerConvPresent} eq "present") {
     if ($self->{cpqHePowerConvCondition} ne "ok") {
       if ($self->{cpqHePowerConvCondition} eq "other") {
-        $self->add_info(sprintf "powerconverter %d is missing",
-            $self->{cpqHePowerConvIndex});
+        $self->add_info("powerconverter %d is missing", \'cpqHePowerConvIndex');
       } else {
-        $self->add_info(sprintf "powerconverter %d needs attention (%s)",
-            $self->{cpqHePowerConvIndex},
-            $self->{cpqHePowerConvCondition});
+        $self->add_info("powerconverter %d needs attention (%s)",
+            \'cpqHePowerConvIndex',
+            \'cpqHePowerConvCondition');
       }
       $self->add_message(CRITICAL, $self->{info});
     } else {
-      $self->add_info(sprintf "powerconverter %d is %s",
-          $self->{cpqHePowerConvIndex},
-          $self->{cpqHePowerConvCondition});
+      $self->add_info("powerconverter %d is %s",
+          \'cpqHePowerConvIndex',
+          \'cpqHePowerConvCondition');
     }
-    $self->add_extendedinfo(sprintf "pc_%s=%s",
-        $self->{cpqHePowerConvIndex},
-        $self->{cpqHePowerConvCondition});
+    $self->add_extendedinfo("pc_%s=%s", \'cpqHePowerConvIndex', \'cpqHePowerConvCondition');
   } else {
-    $self->add_info(sprintf "powerconverter %d is %s",
-        $self->{cpqHePowerConvIndex},
-        $self->{cpqHePowerConvPresent});
-    $self->add_extendedinfo(sprintf "pc_%s=%s",
-        $self->{cpqHePowerConvIndex},
-        $self->{cpqHePowerConvPresent});
+    $self->add_info("powerconverter %d is %s",
+        \'cpqHePowerConvIndex',
+        \'cpqHePowerConvPresent');
+    $self->add_extendedinfo("pc_%s=%s", \'cpqHePowerConvIndex', \'cpqHePowerConvPresent');
   }
 }
 

--- a/plugins-scripts/HP/Proliant/Component/TemperatureSubsystem.pm
+++ b/plugins-scripts/HP/Proliant/Component/TemperatureSubsystem.pm
@@ -122,22 +122,22 @@ sub check {
   my $self = shift;
   $self->blacklist('t', $self->{cpqHeTemperatureIndex});
   if ($self->{cpqHeTemperature} > $self->{cpqHeTemperatureThreshold}) {
-    $self->add_info(sprintf "%d %s temperature too high (%d%s, %d max)",
-        $self->{cpqHeTemperatureIndex}, $self->{cpqHeTemperatureLocale},
-        $self->{cpqHeTemperature}, $self->{cpqHeTemperatureUnits},
-        $self->{cpqHeTemperatureThreshold});
+    $self->add_info("%d %s temperature too high (%d%s, %d max)",
+        \'cpqHeTemperatureIndex', \'cpqHeTemperatureLocale',
+        \'cpqHeTemperature', \'cpqHeTemperatureUnits',
+        \'cpqHeTemperatureThreshold');
     $self->add_message(CRITICAL, $self->{info});
   } elsif ($self->{cpqHeTemperature} < 0) {
     # #21 SCSI_BACKPLANE_ZONE -1C/31F 60C/140F OK - can't be true
-    $self->add_info(sprintf "%d %s temperature too low (%d%s)",
-        $self->{cpqHeTemperatureIndex}, $self->{cpqHeTemperatureLocale},
-        $self->{cpqHeTemperature}, $self->{cpqHeTemperatureUnits});
+    $self->add_info("%d %s temperature too low (%d%s)",
+        \'cpqHeTemperatureIndex', \'cpqHeTemperatureLocale',
+        \'cpqHeTemperature', \'cpqHeTemperatureUnits');
     $self->add_message(CRITICAL, $self->{info});
   } else {
-    $self->add_info(sprintf "%d %s temperature is %d%s (%d max)",
-        $self->{cpqHeTemperatureIndex}, $self->{cpqHeTemperatureLocale}, 
-        $self->{cpqHeTemperature}, $self->{cpqHeTemperatureUnits},
-        $self->{cpqHeTemperatureThreshold});
+    $self->add_info("%d %s temperature is %d%s (%d max)",
+        \'cpqHeTemperatureIndex', \'cpqHeTemperatureLocale', 
+        \'cpqHeTemperature', \'cpqHeTemperatureUnits',
+        \'cpqHeTemperatureThreshold');
   }
   if ($self->{runtime}->{options}->{perfdata} == 2) {
     $self->{runtime}->{plugin}->add_perfdata(
@@ -155,9 +155,7 @@ sub check {
         critical => $self->{cpqHeTemperatureThreshold}
     );
   } 
-  $self->add_extendedinfo(sprintf "temp_%s=%d",
-      $self->{cpqHeTemperatureIndex},
-      $self->{cpqHeTemperature});
+  $self->add_extendedinfo("temp_%s=%d", \'cpqHeTemperatureIndex', \'cpqHeTemperature');
 }
 
 sub dump { 
@@ -181,9 +179,9 @@ use constant { OK => 0, WARNING => 1, CRITICAL => 2, UNKNOWN => 3 };
 sub check {
   my $self = shift;
   $self->blacklist('t', $self->{cpqHeTemperatureIndex});
-  $self->add_info(sprintf "%d %s temperature is %d%s (no thresh.)",
-      $self->{cpqHeTemperatureIndex}, $self->{cpqHeTemperatureLocale}, 
-      $self->{cpqHeTemperature}, $self->{cpqHeTemperatureUnits});
+  $self->add_info("%d %s temperature is %d%s (no thresh.)",
+      \'cpqHeTemperatureIndex', \'cpqHeTemperatureLocale', 
+      \'cpqHeTemperature', \'cpqHeTemperatureUnits');
   if ($self->{runtime}->{options}->{perfdata} == 2) {
     $self->{runtime}->{plugin}->add_perfdata(
         label => sprintf('temp_%s', $self->{cpqHeTemperatureIndex}),
@@ -196,9 +194,7 @@ sub check {
         value => $self->{cpqHeTemperature},
     );
   } 
-  $self->add_extendedinfo(sprintf "temp_%s=%d",
-      $self->{cpqHeTemperatureIndex},
-      $self->{cpqHeTemperature});
+  $self->add_extendedinfo("temp_%s=%d", \'cpqHeTemperatureIndex', \'cpqHeTemperature');
 }
 
 1;

--- a/plugins-scripts/HP/Storage.pm
+++ b/plugins-scripts/HP/Storage.pm
@@ -195,8 +195,7 @@ sub collect {
     # rindsarsch!
     $self->{rawdata}->{$cpqSeMibCondition} = 0;
     if (! exists $self->{rawdata}->{$cpqSeMibCondition}) {
-        $self->add_message(CRITICAL,
-            'snmpwalk returns no health data (cpqhlth-mib)');
+        $self->add_message(CRITICAL, 'snmpwalk returns no health data (cpqhlth-mib)');
     }
   } else {
     my $net_snmp_version = Net::SNMP->VERSION(); # 5.002000 or 6.000000

--- a/plugins-scripts/HP/Storage/Component/CpuSubsystem.pm
+++ b/plugins-scripts/HP/Storage/Component/CpuSubsystem.pm
@@ -77,18 +77,15 @@ sub check {
   if ($self->{status} ne "ok") {
     if ($self->{runtime}->{options}{scrapiron} &&
         ($self->{status} eq "unknown")) {
-      $self->add_info(sprintf "cpu #%d probably ok (%s)",
-          $self->{name}, $self->{status});
+      $self->add_info("cpu #%d probably ok (%s)", \'name', \'status');
     } else {
-      $self->add_info(sprintf "cpu #%d needs attention (%s)",
-          $self->{name}, $self->{status});
+      $self->add_info("cpu #%d needs attention (%s)", \'name', \'status');
       $self->add_message(CRITICAL, $self->{info});
     }
   } else {
-    $self->add_info(sprintf "cpu #%d is %s", $self->{name}, $self->{status});
+    $self->add_info("cpu #%d is %s", \'name', \'status');
   }
-  $self->add_extendedinfo(sprintf "cpu_%s=%s",
-      $self->{name}, $self->{status});
+  $self->add_extendedinfo("cpu_%s=%s", \'name', \'status');
 }
 
 sub dump {

--- a/plugins-scripts/HP/Storage/Component/DiskSubsystem/Da.pm
+++ b/plugins-scripts/HP/Storage/Component/DiskSubsystem/Da.pm
@@ -109,21 +109,18 @@ sub check {
   if ($self->{condition} eq 'other') {
     if (scalar(@{$self->{physical_disks}})) {
       $self->add_message(CRITICAL,
-          sprintf 'da controller in slot %s needs attention', $self->{slot});
-      $self->add_info(sprintf 'da controller in slot %s needs attention',
-          $self->{slot});
+          'da controller in slot %s needs attention', \'slot');
+      $self->add_info('da controller in slot %s needs attention', \'slot');
     } else {
-      $self->add_info(sprintf 'da controller in slot %s is ok and unused',
-          $self->{slot});
+      $self->add_info('da controller in slot %s is ok and unused', \'slot');
       $self->{blacklisted} = 1;
     }
   } elsif ($self->{condition} ne 'ok') {
     $self->add_message(CRITICAL,
-        sprintf 'da controller in slot %s needs attention', $self->{slot});
-    $self->add_info(sprintf 'da controller in slot %s needs attention',
-        $self->{slot});
+        'da controller in slot %s needs attention', \'slot');
+    $self->add_info('da controller in slot %s needs attention', \'slot');
   } else {
-    $self->add_info(sprintf 'da controller in slot %s is ok', $self->{slot});
+    $self->add_info('da controller in slot %s is ok', \'slot');
   }
   foreach (@{$self->{accelerators}}) {
     $_->check();
@@ -193,8 +190,8 @@ sub check {
     # (other) failed degraded
     $self->add_message(CRITICAL, "controller battery needs attention");
   } 
-  $self->add_info(sprintf 'controller cache is %s', $self->{condition});
-  $self->add_info(sprintf 'controller battery is %s', $self->{battery});
+  $self->add_info('controller cache is %s', \'condition');
+  $self->add_info('controller battery is %s', \'battery');
 }
 
 sub dump {
@@ -240,15 +237,12 @@ sub check {
   if ($self->{condition} ne "ok") {
     if ($self->{status} =~ 
         /rebuild|recovering|expanding|queued/) {
-      $self->add_message(WARNING,
-          sprintf "logical drive %s is %s", $self->{name}, $self->{status});
+      $self->add_message(WARNING, 'logical drive %s is %s', \'name', \'status');
     } else {
-      $self->add_message(CRITICAL,
-          sprintf "logical drive %s is %s", $self->{name}, $self->{status});
+      $self->add_message(CRITICAL, 'logical drive %s is %s', \'name', \'status');
     }
   } 
-  $self->add_info(
-      sprintf "logical drive %s is %s", $self->{name}, $self->{status});
+  $self->add_info('logical drive %s is %s', \'name', \'status');
 }
 
 sub dump {
@@ -288,12 +282,9 @@ sub new {
 
 sub check {
   my $self = shift;
-  if ($self->{condition} ne 'ok') {
-    $self->add_message(CRITICAL,
-        sprintf "physical drive %s is %s", $self->{name}, $self->{condition});
-  }
-  $self->add_info(
-      sprintf "physical drive %s is %s", $self->{name}, $self->{condition});
+  my $msg = $self->fmt('physical drive %s is %s', \'name', \'condition');
+  $self->add_message(CRITICAL, $msg) if $self->{condition} ne 'ok';
+  $self->add_info($msg);
 }
 
 sub dump {

--- a/plugins-scripts/HP/Storage/Component/FanSubsystem.pm
+++ b/plugins-scripts/HP/Storage/Component/FanSubsystem.pm
@@ -98,46 +98,38 @@ sub new {
 
 sub check { 
   my $self = shift;
-  $self->add_info(sprintf "fan #%d is %s, speed is %s, pctmax is %s%%, ".
+  $self->add_info("fan #%d is %s, speed is %s, pctmax is %s%%, ".
       "location is %s, redundance is %s, partner is %s",
-      $self->{name}, $self->{present}, $self->{speed}, $self->{pctmax},
-      $self->{location}, $self->{redundant}, $self->{partner});
-  $self->add_extendedinfo(sprintf "fan_%s=%d%%",
-      $self->{name}, $self->{pctmax});
+      \'name', \'present', \'speed', \'pctmax',
+      \'location', \'redundant', \'partner');
+  $self->add_extendedinfo("fan_%s=%d%%", \'name', \'pctmax');
   if ($self->{present} eq "present") {
     if ($self->{speed} eq "high") { 
-      $self->add_info(sprintf "fan #%d (%s) runs at high speed",
-          $self->{name}, $self->{location});
+      $self->add_info("fan #%d (%s) runs at high speed", \'name', \'location');
       $self->add_message(CRITICAL, $self->{info});
     } elsif ($self->{speed} ne "normal") {
-      $self->add_info(sprintf "fan #%d (%s) needs attention",
-          $self->{name}, $self->{location});
+      $self->add_info("fan #%d (%s) needs attention", \'name', \'location');
       $self->add_message(CRITICAL, $self->{info});
     }
     if ($self->{condition} eq "failed") {
-      $self->add_info(sprintf "fan #%d (%s) failed",
-          $self->{name}, $self->{location});
+      $self->add_info("fan #%d (%s) failed", \'name', \'location');
       $self->add_message(CRITICAL, $self->{info});
     } elsif ($self->{condition} eq "degraded") {
-      $self->add_info(sprintf "fan #%d (%s) degraded",
-          $self->{name}, $self->{location});
+      $self->add_info("fan #%d (%s) degraded", \'name', \'location');
       $self->add_message(WARNING, $self->{info});
     } elsif ($self->{condition} ne "ok") {
-      $self->add_info(sprintf "fan #%d (%s) is not ok",
-          $self->{name}, $self->{location});
+      $self->add_info("fan #%d (%s) is not ok", \'name', \'location');
       $self->add_message(WARNING, $self->{info});
     }
     if ($self->{redundant} eq "redundant") {
       if ((! defined $self->{partner}) || ($self->{partner} eq "n/a")){
-        $self->add_info(sprintf "fan #%d (%s) is not redundant",
-            $self->{name}, $self->{location});
+        $self->add_info("fan #%d (%s) is not redundant", \'name', \'location');
         $self->add_message(WARNING, $self->{info});
       }
     } elsif ($self->{redundant} eq "notredundant") {
       if (! $self->{runtime}->{options}->{ignore_fan_redundancy}) {
         if (defined $self->{partner} && $self->{partner} ne "n/a") {
-          $self->add_info(sprintf "fan #%d (%s) is not redundant",
-              $self->{name}, $self->{location});
+          $self->add_info("fan #%d (%s) is not redundant", \'name', \'location');
           $self->add_message(WARNING, $self->{info});
         }
       }
@@ -146,12 +138,10 @@ sub check {
       # maybe redundancy is not supported at all
     }
   } elsif ($self->{present} eq "failed") { # from cli
-    $self->add_info(sprintf "fan #%d (%s) failed",
-        $self->{name}, $self->{location});
+    $self->add_info("fan #%d (%s) failed", \'name', \'location');
     $self->add_message(CRITICAL, $self->{info});
   } elsif ($self->{present} eq "absent") {
-    $self->add_info(sprintf "fan #%d (%s) needs attention (is absent)",
-        $self->{name}, $self->{location});
+    $self->add_info("fan #%d (%s) needs attention (is absent)", \'name', \'location');
     # weiss nicht, ob absent auch kaputt bedeuten kann
     # wenn nicht, dann wuerde man sich hier dumm und daemlich blacklisten
     #$self->add_message(CRITICAL, $self->{info});

--- a/plugins-scripts/HP/Storage/Component/FanSubsystem/SNMP.pm
+++ b/plugins-scripts/HP/Storage/Component/FanSubsystem/SNMP.pm
@@ -232,15 +232,12 @@ sub unite {
 sub overall_check {
   my $self = shift;
   if ($self->{sysstatus} ne 'ok') {
-    $self->add_message(CRITICAL,
-        sprintf 'system fan overall status is %s', $self->{sysstatus});
+    $self->add_message(CRITICAL, 'system fan overall status is %s', \'sysstatus');
   } 
   if ($self->{cpustatus} ne 'ok') {
-    $self->add_message(CRITICAL,
-        sprintf 'cpu fan overall status is %s', $self->{cpustatus});
+    $self->add_message(CRITICAL, 'cpu fan overall status is %s', \'cpustatus');
   } 
-  $self->add_info(sprintf 'overall fan status: fan=%s, cpu=%s',
-      $self->{sysstatus}, $self->{cpustatus});
+  $self->add_info('overall fan status: fan=%s, cpu=%s', \'sysstatus', \'cpustatus');
 }
 
 1;

--- a/plugins-scripts/HP/Storage/Component/MemorySubsystem.pm
+++ b/plugins-scripts/HP/Storage/Component/MemorySubsystem.pm
@@ -47,15 +47,15 @@ sub check {
   } else {
     if ($self->{runtime}->{options}->{ignore_dimms}) {
       $self->add_message(OK,
-          sprintf "ignoring %d dimms with status 'n/a' ",
+          "ignoring %d dimms with status 'n/a' ",
           scalar(grep { ($_->is_present()) } @{$self->{dimms}}));
     } elsif ($self->{runtime}->{options}->{buggy_firmware}) {
       $self->add_message(OK,
-          sprintf "ignoring %d dimms with status 'n/a' because of buggy firmware",
+          "ignoring %d dimms with status 'n/a' because of buggy firmware",
           scalar(grep { ($_->is_present()) } @{$self->{dimms}}));
     } else {
       $self->add_message(WARNING,
-        sprintf "status of all %d dimms is n/a (please upgrade firmware)",
+        "status of all %d dimms is n/a (please upgrade firmware)",
         scalar(grep { $_->is_present() } @{$self->{dimms}}));
         $errorfound++;
     }
@@ -65,8 +65,7 @@ sub check {
   }
   #if (! $errorfound && $self->is_faulty()) {
   if ($self->is_faulty()) {
-    $self->add_message(WARNING,
-        sprintf 'overall memory error %s found', $self->{memstatus});
+    $self->add_message(WARNING, 'overall memory error %s found', \'memstatus');
   }
 }
 
@@ -109,19 +108,18 @@ sub check {
   # die eigentliche bewertung findet eins höher statt
   if (($self->{status} eq 'present') || ($self->{status} eq 'good')) {
     if ($self->{condition} eq 'other') {
-      $self->add_info(sprintf 'dimm module %d @ cartridge %d is n/a',
-          $self->{module}, $self->{cartridge});
+      $self->add_info('dimm module %d @ cartridge %d is n/a',
+          \'module', \'cartridge');
     } elsif ($self->{condition} ne 'ok') {
-      $self->add_info(
-        sprintf "dimm module %d @ cartridge %d needs attention (%s)",
-        $self->{module}, $self->{cartridge}, $self->{condition});
+      $self->add_info('dimm module %d @ cartridge %d needs attention (%s)',
+        \'module', \'cartridge', \'condition');
     } else {
-      $self->add_info(sprintf 'dimm module %d @ cartridge %d is %s',
-          $self->{module}, $self->{cartridge}, $self->{condition});
+      $self->add_info('dimm module %d @ cartridge %d is %s',
+          \'module', \'cartridge', \'condition');
     }
   } else {
-    $self->add_info(sprintf 'dimm module %d @ cartridge %d is not present',
-        $self->{module}, $self->{cartridge});
+    $self->add_info('dimm module %d @ cartridge %d is not present',
+        \'module', \'cartridge');
   }
 }
 

--- a/plugins-scripts/HP/Storage/Component/Powersupply.pm
+++ b/plugins-scripts/HP/Storage/Component/Powersupply.pm
@@ -44,23 +44,18 @@ sub check {
   if ($self->{present} eq "present") {
     if ($self->{condition} ne "ok") {
       if ($self->{condition} eq "n/a") {
-        $self->add_info(sprintf "powersupply #%d is missing", $self->{name});
+        $self->add_info("powersupply #%d is missing", \'name');
       } else {
-        $self->add_info(sprintf "powersupply #%d needs attention (%s)",
-            $self->{name}, $self->{condition});
+        $self->add_info("powersupply #%d needs attention (%s)", \'name', \'condition');
       }
       $self->add_message(CRITICAL, $self->{info});
     } else {
-      $self->add_info(sprintf "powersupply #%d is %s",
-          $self->{name}, $self->{condition});
+      $self->add_info("powersupply #%d is %s", \'name', \'condition');
     }
-    $self->add_extendedinfo(sprintf "ps_%s=%s",
-        $self->{name}, $self->{condition});
+    $self->add_extendedinfo("ps_%s=%s", \'name', \'condition');
   } else {
-    $self->add_info(sprintf "powersupply #%d is %s", 
-        $self->{name}, $self->{present});
-    $self->add_extendedinfo(sprintf "ps_%s=%s",
-        $self->{name}, $self->{present});
+    $self->add_info("powersupply #%d is %s", \'name', \'present');
+    $self->add_extendedinfo("ps_%s=%s", \'name', \'present');
   } 
 }
 

--- a/plugins-scripts/HP/Storage/Component/PowersupplySubsystem.pm
+++ b/plugins-scripts/HP/Storage/Component/PowersupplySubsystem.pm
@@ -78,23 +78,18 @@ sub check {
   if ($self->{present} eq "present") {
     if ($self->{condition} ne "ok") {
       if ($self->{condition} eq "n/a") {
-        $self->add_info(sprintf "powersupply #%d is missing", $self->{name});
+        $self->add_info("powersupply #%d is missing", \'name');
       } else {
-        $self->add_info(sprintf "powersupply #%d needs attention (%s)",
-            $self->{name}, $self->{condition});
+        $self->add_info("powersupply #%d needs attention (%s)", \'name', \'condition');
       }
       $self->add_message(CRITICAL, $self->{info});
     } else {
-      $self->add_info(sprintf "powersupply #%d is %s",
-          $self->{name}, $self->{condition});
+      $self->add_info("powersupply #%d is %s", \'name', \'condition');
     }
-    $self->add_extendedinfo(sprintf "ps_%s=%s",
-        $self->{name}, $self->{condition});
+    $self->add_extendedinfo("ps_%s=%s", \'name', \'condition');
   } else {
-    $self->add_info(sprintf "powersupply #%d is %s",
-        $self->{name}, $self->{present});
-    $self->add_extendedinfo(sprintf "ps_%s=%s",
-        $self->{name}, $self->{present});
+    $self->add_info("powersupply #%d is %s", \'name', \'present');
+    $self->add_extendedinfo("ps_%s=%s", \'name', \'present');
   }
 }
 

--- a/plugins-scripts/HP/Storage/Component/TemperatureSubsystem.pm
+++ b/plugins-scripts/HP/Storage/Component/TemperatureSubsystem.pm
@@ -92,14 +92,13 @@ sub new {
 sub check {
   my $self = shift;
   if ($self->{degrees} > $self->{threshold}) {
-    $self->add_info(sprintf "%s temperature too high (%d%s)",
-        $self->{location}, $self->{degrees},
-        $self->{runtime}->{options}->{celsius} ? "C" : "F");
+    $self->add_info("%s temperature too high (%d%s)",
+        \'location',\'degrees',
+        $self->{runtime}{options}{celsius} ? "C" : "F");
     $self->add_message(CRITICAL, $self->{info});
   } else {
-    $self->add_info(sprintf "%d %s temperature is %d (%d max)",
-        $self->{name}, $self->{location}, 
-        $self->{degrees}, $self->{threshold});
+    $self->add_info("%d %s temperature is %d (%d max)",
+        \'name', \'location', \'degrees', \'threshold');
   }
   if ($self->{runtime}->{options}->{perfdata} == 2) {
     $self->{runtime}->{plugin}->add_perfdata(
@@ -116,9 +115,7 @@ sub check {
         critical => $self->{threshold}
     );
   } 
-  $self->add_extendedinfo(sprintf "temp_%s=%d",
-      $self->{name},
-      $self->{degrees});
+  $self->add_extendedinfo("temp_%s=%d", \'name', \'degrees');
 }
 
 sub dump { 

--- a/plugins-scripts/check_hpasm.pl
+++ b/plugins-scripts/check_hpasm.pl
@@ -151,7 +151,7 @@ $plugin->add_arg(
 $plugin->add_arg(
     spec => 'eval-nics',
     help => '--eval-nics
-   Check network interfaces (and groups). Try it and report me whyt you think about it. I need to build up some know how on this subject. If get an error and you think, it is not justified for your configuration, please tell me about it. (alwasy send the output of "snmpwalk -On .... 1.3.6.1.4.1.232" and a description how you setup your nics and why it is correct opposed to the plugins error message',
+   Check network interfaces (and groups). Try it and report me what you think about it. I need to build up some know how on this subject. If get an error and you think, it is not justified for your configuration, please tell me about it. (always send the output of "snmpwalk -On .... 1.3.6.1.4.1.232" and a description how you setup your nics and why it is correct opposed to the plugin\'s error message',
     required => 0,
 );
 


### PR DESCRIPTION
Move `sprintf` message formatting into its own object method of `HP::Server` and make `add_info()`, `add_extendedinfo()` and `add_message()` use it. This way
    
* The first argument is always a format string. Should there be no further arguments, the `sprintf` is a no-op.
* Additional arguments can be either scalar references or plain scalars. Every reference is taken to be the name of an attribute to retrieve; plain scalars are taken as-is.
    
This saves a lot of typing and makes code somewhat easier to read by replacing all the nested
`add_info(sprintf "foo %s bar %d%s", $self->{attr1}, $self->{attr2}, 'quux')`
calls with
`add_info('foo %s bar %d%s', \'attr1', \'attr2', 'quux')`.

Considering that attribute lookups are much more frequent in arguments to `add_info` etc. than calculated arguments, it would make sense to reverse the semantics and insert scalar references as-is while plain
scalars would be taken as attribute names. This would save a heap of unsightly backslashes. However, the way it is now is completely compatible with the old calling conventions so it should be the gentler change after all.

I just came up with this while adding `--customfanspeeds` and actually did it first, however to make the two changes independent I based the customfanspeeds change on the master as well as this is a fairly big one stylistically :)