### PR TITLE
Warning on battery notPresent

### DIFF
--- a/plugins-scripts/HP/Proliant.pm
+++ b/plugins-scripts/HP/Proliant.pm
@@ -361,19 +361,16 @@ EOEO
           if ($self->{runtime}->{options}->{hpacucli}) {
             #1 oder 0. pfad selber finden
             my $hpacucli = undef;
-            if (-e '/usr/sbin/hpssacli') {
-              $hpacucli = '/usr/sbin/hpssacli';
-            } elsif (-e '/usr/local/sbin/hpssacli') {
-              $hpacucli = '/usr/local/sbin/hpssacli';
-            } elsif (-e '/usr/sbin/hpacucli') {
-              $hpacucli = '/usr/sbin/hpacucli';
-            } elsif (-e '/usr/local/sbin/hpacucli') {
-              $hpacucli = '/usr/local/sbin/hpacucli';
-            } elsif (-e '/usr/sbin/hpssacli') {
-              $hpacucli = '/usr/sbin/hpssacli';
-            } elsif (-e '/usr/local/sbin/hpssacli') {
-              $hpacucli = '/usr/local/sbin/hpssacli';
-            } else {
+            CLIEXECTEST:
+            foreach my $cliexec (qw(ssacli hpssacli hpacucli)) {
+              foreach my $clipaths (qw(/usr/sbin/ /usr/local/sbin/ /sbin/)) {
+                if (-e $clipaths . $cliexec) {
+                  $hpacucli = $clipaths . $cliexec;
+                  last CLIEXECTEST;
+                }
+              }
+            }
+            if (! defined $hpacucli) {
               $hpacucli = $hpasmcli;
               $hpacucli =~ s/^sudo\s*//;
               $hpacucli =~ s/hpasmcli/hpacucli/;

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da.pm
@@ -189,6 +189,8 @@ sub check {
   $self->add_info(sprintf 'controller accelerator battery is %s',
       $self->{cpqDaAccelBattery});
   if ($self->{cpqDaAccelBattery} eq "notPresent") {
+    # permenently disabled battery return as notPresent even when it is disabled because of a faulty battery
+    $self->add_message(WARNING, "controller accelerator battery needs attention");
   } elsif ($self->{cpqDaAccelBattery} eq "recharging") {
     $self->add_message(WARNING, "controller accelerator battery recharging");
   } elsif ($self->{cpqDaAccelBattery} eq "failed" &&


### PR DESCRIPTION
The check currently doesn't trigger a warning on the battery accelerator being "notPresent".  The battery status will be "notPresent" if the cache is permanently disabled due to a faulty battery being present.

I have also added in the changes from https://github.com/lausser/check_hpasm/pull/16 for the name change