### PR TITLE
Storage gen11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+Makefile
+Makefile.in
+autom4te.cache/
+config.log
+config.status
+configure
+plugins-scripts/Makefile
+plugins-scripts/Makefile.in
+plugins-scripts/check_hpasm
+plugins-scripts/subst
+

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da.pm
@@ -366,11 +366,11 @@ sub check {
   $self->blacklist('dapd', $self->{name});
   $self->add_info(
       sprintf "physical drive %s is %s",
-          $self->{name}, $self->{cpqDaPhyDrvCondition});
-  if ($self->{cpqDaPhyDrvCondition} ne 'ok') {
+          $self->{name}, $self->{cpqDaPhyDrvStatus});
+  if ($self->{cpqDaPhyDrvStatus} ne 'ok') {
     $self->add_message(CRITICAL,
         sprintf "physical drive %s is %s", 
-            $self->{name}, $self->{cpqDaPhyDrvCondition});
+            $self->{name}, $self->{cpqDaPhyDrvStatus});
   }
 }
 

--- a/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da/SNMP.pm
+++ b/plugins-scripts/HP/Proliant/Component/DiskSubsystem/Da/SNMP.pm
@@ -220,6 +220,11 @@ sub init {
           2 => "ok",
           3 => "failed",
           4 => "predictiveFailure",
+	  5 => "erasing",
+	  6 => "eraseDone",
+	  7 => "eraseQueued",
+	  8 => "ssdWearOut",
+	  9 => "notAuthenticated",
       },
   };
     

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+aclocal
+autoheader
+automake --add-missing --copy
+autoconf
+./configure


### PR DESCRIPTION
CH: replace cpqDaPhyDrvCondition with cpqDaPhyDrvStatus

ilo5 starting with version 3.0 (or a little bit earlier) does not
report drive status in condition. This is stated as
cpqDaPhyDrvHasMonInfo is false.
Using cpqDaPhyDrvStatus which is always populated.

Should fix #28 and #20