### PR TITLE
Show fans as degraded when Partner is N/A

### DIFF
--- a/plugins-scripts/HP/Proliant/Component/FanSubsystem/CLI.pm
+++ b/plugins-scripts/HP/Proliant/Component/FanSubsystem/CLI.pm
@@ -73,6 +73,8 @@ sub init {
         $tmpfan{cpqHeFltTolFanCondition} = 'failed';
       } elsif($tmpfan{cpqHeFltTolFanSpeed} eq 'n/a') {
         $tmpfan{cpqHeFltTolFanCondition} = 'other';
+      } elsif($tmpfan{cpqHeFltTolFanPresent} eq 'yes' and $tmpfan{cpqHeFltTolFanRedundantPartner} eq 'n/a') {
+        $tmpfan{cpqHeFltTolFanCondition} = 'degraded';
       } else {
         $tmpfan{cpqHeFltTolFanCondition} = 'ok';
       }


### PR DESCRIPTION
hpasm doesn't directly show the fan as degraded but the partner column is N/A for degraded fans